### PR TITLE
Fix bug where subsequent split lines would be over split.

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -112,6 +112,7 @@ func (e *Encoder) Encode(m Metric) (int, error) {
 			if err != nil {
 				return 0, err
 			}
+			pairsLen = 0
 			totalWritten += i
 
 			bytesNeeded = len(e.header) + len(e.pair) + len(e.footer)

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -354,6 +354,22 @@ var tests = []struct {
 		output: []byte("cpu abc=123i 1519194109000000042\ncpu def=456i 1519194109000000042\n"),
 	},
 	{
+		name:     "split_fields_overflow",
+		maxBytes: 43,
+		input: NewMockMetric(
+			"cpu",
+			map[string]string{},
+			map[string]interface{}{
+				"abc": 123,
+				"def": 456,
+				"ghi": 789,
+				"jkl": 123,
+			},
+			time.Unix(1519194109, 42),
+		),
+		output: []byte("cpu abc=123i,def=456i 1519194109000000042\ncpu ghi=789i,jkl=123i 1519194109000000042\n"),
+	},
+	{
 		name: "name newline",
 		input: NewMockMetric(
 			"c\npu",


### PR DESCRIPTION
Fixes issue where after the first split line, all remaining fields would be split on each field:
```
cpu abc=123i,def=456i 1519194109000000042
cpu ghi=789i1519194109000000042
cpu jkl=123i 1519194109000000042
```

https://github.com/influxdata/telegraf/pull/5439