### PR TITLE
fix(encoder): return an error when _measurement, _field or time tag keys are used

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -193,8 +193,15 @@ func (e *Encoder) buildHeader(m Metric) error {
 
 		// Some keys and values are not encodeable as line protocol, such as
 		// those with a trailing '\' or empty strings.
-		if key == "" || value == "" {
+		if value == "" {
 			continue
+		}
+
+		switch key {
+		case "":
+			continue
+		case "_measurement", "_field", "time":
+			return ErrTagKeyReserved
 		}
 
 		e.header = append(e.header, ',')

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -508,6 +508,48 @@ var tests = []struct {
 		failOnFieldErr: true,
 		err:            ErrIsNaN,
 	},
+	{
+		name: "error use of reserved _measurement tag key",
+		input: NewMockMetric(
+			"cpu",
+			map[string]string{
+				"_measurement": "cpu",
+			},
+			map[string]interface{}{
+				"value": 42.0,
+			},
+			time.Unix(0, 0),
+		),
+		err: ErrTagKeyReserved,
+	},
+	{
+		name: "error use of reserved _field tag key",
+		input: NewMockMetric(
+			"cpu",
+			map[string]string{
+				"_field": "value",
+			},
+			map[string]interface{}{
+				"value": 42.0,
+			},
+			time.Unix(0, 0),
+		),
+		err: ErrTagKeyReserved,
+	},
+	{
+		name: "error use of reserved time tag key",
+		input: NewMockMetric(
+			"cpu",
+			map[string]string{
+				"time": "1234567890123",
+			},
+			map[string]interface{}{
+				"value": 42.0,
+			},
+			time.Unix(0, 0),
+		),
+		err: ErrTagKeyReserved,
+	},
 }
 
 func TestEncoder(t *testing.T) {

--- a/escape.go
+++ b/escape.go
@@ -112,42 +112,6 @@ func escapeBytes(dest *[]byte, b []byte) {
 	*dest = append(*dest, b...)
 }
 
-// Escape a measurement name
-func nameEscapeBytes(dest *[]byte, b []byte) {
-	if bytes.ContainsAny(b, nameEscapes) {
-		var r rune
-		for i, j := 0, 0; i < len(b); i += j {
-			r, j = utf8.DecodeRune(b[i:])
-			switch {
-			case r == '\t':
-				*dest = append(*dest, `\t`...)
-			case r == '\n':
-				*dest = append(*dest, `\n`...)
-			case r == '\f':
-				*dest = append(*dest, `\f`...)
-			case r == '\r':
-				*dest = append(*dest, `\r`...)
-			case r == ',':
-				*dest = append(*dest, `\,`...)
-			case r == ' ':
-				*dest = append(*dest, `\ `...)
-			case r == '\\':
-				*dest = append(*dest, `\\`...)
-			case r <= 1<<7-1:
-				*dest = append(*dest, byte(r))
-			case r <= 1<<11-1:
-				*dest = append(*dest, utf8len2|byte(r>>6), utf8bytex|byte(r)&utf8mask)
-			case r <= 1<<16-1:
-				*dest = append(*dest, utf8len3|byte(r>>12), utf8bytex|byte(r>>6)&utf8mask, utf8bytex|byte(r)&utf8mask)
-			default:
-				*dest = append(*dest, utf8len4|byte(r>>18), utf8bytex|byte(r>>12)&utf8mask, utf8bytex|byte(r>>6)&utf8mask, utf8bytex|byte(r)&utf8mask)
-			}
-		}
-		return
-	}
-	*dest = append(*dest, b...)
-}
-
 func stringFieldEscapeBytes(dest *[]byte, b []byte) {
 	if bytes.ContainsAny(b, stringFieldEscapes) {
 		var r rune

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/influxdata/line-protocol
+
+go 1.12

--- a/metric.go
+++ b/metric.go
@@ -68,4 +68,8 @@ var (
 
 	// ErrNoFields tells us that there were no serializable fields in the line/metric.
 	ErrNoFields = &MetricError{"no serializable fields"}
+
+	// ErrTagKeyReserved tells us that the tag key attempting to be serialized is reserved
+	// i.e. one of "_measurement", "_field" or "time".
+	ErrTagKeyReserved = &MetricError{"tag key is reserved"}
 )

--- a/writer.go
+++ b/writer.go
@@ -1,130 +1,53 @@
 package protocol
 
 import (
-	"fmt"
 	"time"
 )
 
+type metric struct {
+	name   string
+	tags   []*Tag
+	fields []*Field
+	t      time.Time
+}
+
+func (m *metric) Name() string {
+	return m.name
+}
+func (m *metric) TagList() []*Tag {
+	return m.tags
+}
+
+func (m *metric) FieldList() []*Field {
+	return m.fields
+}
+
+func (m *metric) Time() time.Time {
+	return m.t
+}
+
 // Write writes out data to a line protocol encoder.  Note: it does no sorting.  It assumes you have done your own sorting for tagValues
 func (e *Encoder) Write(name []byte, ts time.Time, tagKeys, tagVals, fieldKeys [][]byte, fieldVals []interface{}) (int, error) {
-	e.header = e.header[:0]
-	if len(name) == 0 || name[len(name)-1] == byte('\\') {
-		return 0, ErrInvalidName
+	metric := &metric{
+		name:   string(name),
+		t:      ts,
+		tags:   make([]*Tag, len(tagKeys)),
+		fields: make([]*Field, len(fieldKeys)),
 	}
-	nameEscapeBytes(&e.header, name)
+
 	for i := range tagKeys {
-		// Some keys and values are not encodeable as line protocol, such as
-		// those with a trailing '\' or empty strings.
-		if len(tagKeys[i]) == 0 || len(tagVals[i]) == 0 || tagKeys[i][len(tagKeys[i])-1] == byte('\\') {
-			if e.failOnFieldError {
-				return 0, fmt.Errorf("invalid field: key \"%s\", val \"%s\"", tagKeys[i], tagVals[i])
-			}
-			continue
+		metric.tags[i] = &Tag{
+			Key:   string(tagKeys[i]),
+			Value: string(tagVals[i]),
 		}
-		e.header = append(e.header, byte(','))
-		escapeBytes(&e.header, tagKeys[i])
-		e.header = append(e.header, byte('='))
-		escapeBytes(&e.header, tagVals[i])
 	}
-	e.header = append(e.header, byte(' '))
-	e.buildFooter(ts)
 
-	i := 0
-	totalWritten := 0
-	pairsLen := 0
-	firstField := true
 	for i := range fieldKeys {
-		e.pair = e.pair[:0]
-		key := fieldKeys[i]
-		if len(key) == 0 || key[len(key)-1] == byte('\\') {
-			if e.failOnFieldError {
-				return 0, &FieldError{"invalid field key"}
-			}
-			continue
+		metric.fields[i] = &Field{
+			Key:   string(fieldKeys[i]),
+			Value: fieldVals[i],
 		}
-		escapeBytes(&e.pair, key)
-		// Some keys are not encodeable as line protocol, such as those with a
-		// trailing '\' or empty strings.
-		e.pair = append(e.pair, byte('='))
-		err := e.buildFieldVal(fieldVals[i])
-		if err != nil {
-			if e.failOnFieldError {
-				return 0, err
-			}
-			continue
-		}
-
-		bytesNeeded := len(e.header) + pairsLen + len(e.pair) + len(e.footer)
-
-		// Additional length needed for field separator `,`
-		if !firstField {
-			bytesNeeded++
-		}
-
-		if e.maxLineBytes > 0 && bytesNeeded > e.maxLineBytes {
-			// Need at least one field per line
-			if firstField {
-				return 0, ErrNeedMoreSpace
-			}
-
-			i, err = e.w.Write(e.footer)
-			if err != nil {
-				return 0, err
-			}
-			totalWritten += i
-
-			bytesNeeded = len(e.header) + len(e.pair) + len(e.footer)
-
-			if e.maxLineBytes > 0 && bytesNeeded > e.maxLineBytes {
-				return 0, ErrNeedMoreSpace
-			}
-
-			i, err = e.w.Write(e.header)
-			if err != nil {
-				return 0, err
-			}
-			totalWritten += i
-
-			i, err = e.w.Write(e.pair)
-			if err != nil {
-				return 0, err
-			}
-			totalWritten += i
-
-			pairsLen += len(e.pair)
-			firstField = false
-			continue
-		}
-
-		if firstField {
-			i, err = e.w.Write(e.header)
-			if err != nil {
-				return 0, err
-			}
-			totalWritten += i
-
-		} else {
-			i, err = e.w.Write(comma)
-			if err != nil {
-				return 0, err
-			}
-			totalWritten += i
-
-		}
-
-		e.w.Write(e.pair)
-
-		pairsLen += len(e.pair)
-		firstField = false
 	}
 
-	if firstField {
-		return 0, ErrNoFields
-	}
-	i, err := e.w.Write(e.footer)
-	if err != nil {
-		return 0, err
-	}
-	totalWritten += i
-	return totalWritten, nil
+	return e.Encode(metric)
 }


### PR DESCRIPTION
This PR adds the validation which rejects tags with the keys `_measurement`, `_field` or `time`.
Attempting to do so will result in an error.

It also fixes master. It appears it has been broken for a while. This updates the `Write()` method to use the `Encode()` method directly.