### PR TITLE
feat: influxdata: initial tokenization primitives

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.15.2
+
+    working_directory: /go/src/github.com/influxdata/line-protocol
+    steps:
+      - checkout
+      - run: go get honnef.co/go/tools/...
+      - run: go test -v ./...
+      - run: go vet -v ./...
+      - run: staticcheck ./...

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/influxdata/line-protocol
+
+go 1.15
+
+require github.com/frankban/quicktest v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/frankban/quicktest v1.11.0 h1:Yyrghcw93e1jKo4DTZkRFTTFvBsVhzbblBUPNU1vW6Q=
+github.com/frankban/quicktest v1.11.0/go.mod h1:K+q6oSqb0W0Ininfk863uOk1lMy69l/P6txr3mVT54s=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/influxdata/byteset.go
+++ b/influxdata/byteset.go
@@ -1,0 +1,55 @@
+package influxdata
+
+// save these methods from staticcheck. we're going to use them later.
+var (
+	_ = whitespace
+	_ = (*byteSet).union
+)
+
+// newByteset returns a set representation
+// of the given bytes.
+func newByteSet(bytes ...byte) *byteSet {
+	var set byteSet
+	for _, b := range bytes {
+		set.set(b)
+	}
+	return &set
+}
+
+// TODO benchmark it. This is compact (good cache behaviour)
+// but maybe [256]bool might be faster (less operations).
+type byteSet [4]uint64
+
+// holds reports whether b holds the byte x.
+func (b *byteSet) get(x uint8) bool {
+	return b[x>>6]&(1<<(x&63)) != 0
+}
+
+// set ensures that x is in the set.
+func (b *byteSet) set(x uint8) {
+	b[x>>6] |= 1 << (x & 63)
+}
+
+// union returns the union of b and b1.
+func (b *byteSet) union(b1 *byteSet) *byteSet {
+	r := *b
+	for i := range r {
+		r[i] |= b1[i]
+	}
+	return &r
+}
+
+// invert returns everything not in b.
+func (b *byteSet) invert() *byteSet {
+	r := *b
+	for i := range r {
+		r[i] = ^r[i]
+	}
+	return &r
+}
+
+// whitespace returns a set containing all characters
+// recognized as white space.
+func whitespace() *byteSet {
+	return newByteSet(' ', '\t', '\n', '\r', '\f')
+}

--- a/influxdata/tokenizer.go
+++ b/influxdata/tokenizer.go
@@ -1,0 +1,143 @@
+package influxdata
+
+import (
+	"io"
+)
+
+// minRead holds the minimum buffer size passed to io.Reader.Read.
+const minRead = 8192
+
+// NewTokenizer returns a tokenizer that splits the line-protocol text
+// inside buf. The text in buf represent a complete line (or multiple lines) - that
+// is, the tokenization will not work correctly if presented with a line
+// split at an arbitrary place.
+func NewTokenizerWithBytes(buf []byte) *Tokenizer {
+	return &Tokenizer{
+		buf:      buf,
+		complete: true,
+	}
+}
+
+func NewTokenizer(r io.Reader) *Tokenizer {
+	return &Tokenizer{
+		rd: r,
+	}
+}
+
+// Tokenizer implements low level parsing of a line-protocol message.
+type Tokenizer struct {
+	// rd holds the reader, if any. If there is no reader,
+	// complete will be true.
+	rd io.Reader
+
+	// buf holds read data.
+	buf []byte
+
+	// complete holds whether the data in buffer
+	// is known to be all the data that's available.
+	complete bool
+
+	// r holds the read position in buf.
+	r int
+
+	// err holds any non-EOF error that was returned from rd.
+	err error
+}
+
+// take returns the next slice of bytes within t.buf that are in the given set
+// starting at t.r + from, reading more data as needed.
+//
+// It does not update t.r.
+func (t *Tokenizer) take(set *byteSet, from int) []byte {
+	n := from
+outer:
+	for {
+		if !t.ensure(n + 1) {
+			break
+		}
+		buf := t.buf[t.r+n:]
+		for i, c := range buf {
+			if !set.get(c) {
+				n += i
+				break outer
+			}
+		}
+		n += len(buf)
+	}
+	return t.buf[t.r+from : t.r+n]
+}
+
+// at returns the byte at i bytes after the current read position.
+// It assumes that the byte has already been read (use t.ensure to check
+// whether it's there).
+func (t *Tokenizer) at(i int) byte {
+	return t.buf[t.r+i]
+}
+
+// discard advances the read offset by n bytes.
+// There must be at least n bytes available in the buffer.
+func (t *Tokenizer) discard(n int) {
+	t.r += n
+	if t.r == len(t.buf) {
+		// No bytes in the buffer, so we can start from the beginning without
+		// needing to copy anything (and get better cache behaviour too).
+		t.buf = t.buf[:0]
+		t.r = 0
+	}
+}
+
+// ensure ensures that there are at least n bytes available in
+// t.buf[t.r:], reading more bytes if necessary.
+// It reports whether enough bytes are available.
+func (t *Tokenizer) ensure(n int) bool {
+	for {
+		if t.r+n <= len(t.buf) {
+			// There are enough bytes available.
+			return true
+		}
+		if t.complete {
+			// No possibility of more data.
+			return false
+		}
+		t.readMore()
+	}
+}
+
+// readMore reads more data into t.buf.
+func (t *Tokenizer) readMore() {
+	if t.complete {
+		return
+	}
+	n := cap(t.buf) - len(t.buf)
+	if n < minRead {
+		// There's not enough available space at the end of the buffer to read into.
+		if n+t.r >= minRead {
+			// There's enough space when we take into account already-used
+			// part of buf, so slide the data to the front.
+			copy(t.buf, t.buf[t.r:])
+			t.buf = t.buf[:len(t.buf)-t.r]
+		} else {
+			// We need to grow the buffer. Note that we don't have to copy
+			// the unused part of the buffer (t.buf[:t.r]).
+			// TODO provide a way to limit the maximum size that
+			// the buffer can grow to.
+			used := len(t.buf) - t.r
+			n1 := cap(t.buf) * 2
+			if n1-used < minRead {
+				n1 = used + minRead
+			}
+			buf1 := make([]byte, used, n1)
+			copy(buf1, t.buf[t.r:])
+			t.buf = buf1
+		}
+	}
+	n, err := t.rd.Read(t.buf[len(t.buf):cap(t.buf)])
+	t.buf = t.buf[:len(t.buf)+n]
+	if err == nil {
+		return
+	}
+	t.complete = true
+	if err != io.EOF {
+		t.err = err
+	}
+}

--- a/influxdata/tokenizer_test.go
+++ b/influxdata/tokenizer_test.go
@@ -1,0 +1,110 @@
+package influxdata
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"testing/iotest"
+
+	qt "github.com/frankban/quicktest"
+)
+
+var tokenizerTakeTests = []struct {
+	testName     string
+	newTokenizer func(s string) *Tokenizer
+	expectError  string
+}{{
+	testName: "bytes",
+	newTokenizer: func(s string) *Tokenizer {
+		return NewTokenizerWithBytes([]byte(s))
+	},
+}, {
+	testName: "reader",
+	newTokenizer: func(s string) *Tokenizer {
+		return NewTokenizer(strings.NewReader(s))
+	},
+}, {
+	testName: "one-byte-reader",
+	newTokenizer: func(s string) *Tokenizer {
+		return NewTokenizer(iotest.OneByteReader(strings.NewReader(s)))
+	},
+}, {
+	testName: "data-err-reader",
+	newTokenizer: func(s string) *Tokenizer {
+		return NewTokenizer(iotest.DataErrReader(strings.NewReader(s)))
+	},
+}, {
+	testName: "error-reader",
+	newTokenizer: func(s string) *Tokenizer {
+		return NewTokenizer(&errorReader{
+			r:   strings.NewReader(s),
+			err: fmt.Errorf("some error"),
+		})
+	},
+	expectError: "some error",
+}}
+
+// TestTokenizerTake tests the internal Tokenizer.take method.
+func TestTokenizerTake(t *testing.T) {
+	c := qt.New(t)
+	for _, test := range tokenizerTakeTests {
+		c.Run(test.testName, func(c *qt.C) {
+			s := "aabbcccddefga"
+			tok := test.newTokenizer(s)
+			data1 := tok.take(newByteSet('a', 'b', 'c'), 0)
+			c.Assert(string(data1), qt.Equals, "aabbccc")
+
+			data2 := tok.take(newByteSet('d'), len(data1))
+			c.Assert(string(data2), qt.Equals, "dd")
+			c.Assert(tok.r, qt.Equals, 0)
+
+			data3 := tok.take(newByteSet(' ').invert(), len(data1)+len(data2))
+			c.Assert(string(data3), qt.Equals, "efga")
+			c.Assert(tok.complete, qt.Equals, true)
+
+			data4 := tok.take(newByteSet(' ').invert(), len(data1)+len(data2)+len(data3))
+			c.Assert(string(data4), qt.Equals, "")
+
+			data5 := tok.take(newByteSet('a', 'b', 'c'), len(s))
+			c.Assert(string(data5), qt.Equals, "")
+
+			// Check that none of them have been overwritten.
+			c.Assert(string(data1), qt.Equals, "aabbccc")
+			c.Assert(string(data2), qt.Equals, "dd")
+			c.Assert(string(data3), qt.Equals, "efga")
+			if test.expectError != "" {
+				c.Assert(tok.err, qt.ErrorMatches, test.expectError)
+			} else {
+				c.Assert(tok.err, qt.IsNil)
+			}
+		})
+	}
+}
+
+func TestTokenizerTakeWithDiscard(t *testing.T) {
+	c := qt.New(t)
+	// With a byte-at-a-time reader, we won't read any more
+	// than we absolutely need, so discard should cause the
+	// buffer to be overwritten each time.
+	tok := NewTokenizer(iotest.OneByteReader(strings.NewReader("aabbcccddefg")))
+	data1 := tok.take(newByteSet('a', 'b', 'c'), 0)
+	c.Assert(string(data1), qt.Equals, "aabbccc")
+	tok.discard(len(data1))
+	c.Assert(tok.at(0), qt.Equals, byte('d'))
+	tok.discard(1)
+	c.Assert(tok.r, qt.Equals, 0)
+}
+
+type errorReader struct {
+	r   io.Reader
+	err error
+}
+
+func (r *errorReader) Read(buf []byte) (int, error) {
+	n, err := r.r.Read(buf)
+	if err != nil {
+		err = r.err
+	}
+	return n, err
+}


### PR DESCRIPTION
This represents the first steps towards a (hopefully) fast and zero-
or near-zero allocation line-protocol tokenizer that can be used as the
basis for a higher level package API TBD.

The package name is, of course, subject to bikeshedding. I'm keen
that, regardless of the chosen name, the package name should
match the last element of its import path
(unlike the current `github.com/influxdata/line-protocol`, which is non-descriptly
named `protocol`).

As this is a low level API, there are a few convenience trade-offs that
are being made in anticipation of performance benefits:

- methods do not return errors. If there's a read error, that will be
picked up at a higher level - in general we want to consume as much
data as possible even in the face of a read error - and this reduces
call overhead too.

- we anticipate that several sections of the input will want to be kept
around at the same time (so we can return both a key and a value from
the same call without extra copies or allocations), hence the "from"
argument to `take` and `isEmpty`, allowing the higher level methods to
manage the contents of the buffer while consuming input.