### PR TITLE
feat: influxdata: add Tokenizer.takeEsc

### DIFF
--- a/influxdata/escape.go
+++ b/influxdata/escape.go
@@ -1,0 +1,33 @@
+package influxdata
+
+import (
+	"strconv"
+	"strings"
+)
+
+// escaper represents a set of characters that can be escaped.
+type escaper struct {
+	// table maps from byte value to the byte used to escape that value.
+	// If an entry is zero, it doesn't need to be escaped.
+	table [256]byte
+
+	// revTable holds the inverse of table - it maps
+	// from escaped value to the unescaped value.
+	revTable [256]byte
+}
+
+// newEscaper returns an escaper that escapes the
+// given characters.
+func newEscaper(escapes string) *escaper {
+	var e escaper
+	for _, b := range escapes {
+		// Note that this works because the Go escaping rules
+		// for white space are the same as line-protocol's.
+		q := strconv.QuoteRune(b)
+		q = q[1 : len(q)-1]             // strip single quotes.
+		q = strings.TrimPrefix(q, "\\") // remove backslash if present.
+		e.table[byte(b)] = q[0]         // use single remaining character.
+		e.revTable[q[0]] = byte(b)
+	}
+	return &e
+}

--- a/influxdata/tokenizer.go
+++ b/influxdata/tokenizer.go
@@ -5,7 +5,46 @@ import (
 )
 
 // minRead holds the minimum buffer size passed to io.Reader.Read.
-const minRead = 8192
+const (
+	// When the buffer is grown, it will be grown be a minimum of 8K.
+	minGrow = 8192
+	// The buffer will be grown if there's less than minRead space available
+	// to read into.
+	minRead = minGrow / 2
+)
+
+// Tokenizer implements low level parsing of a line-protocol message.
+type Tokenizer struct {
+	// rd holds the reader, if any. If there is no reader,
+	// complete will be true.
+	rd io.Reader
+
+	// buf holds data that's been read.
+	buf []byte
+
+	// complete holds whether the data in buffer
+	// is known to be all the data that's available.
+	complete bool
+
+	// skipping holds whether we will need
+	// to return the values that we're tokenizing.
+	skipping bool
+
+	// r0 holds the earliest read position in buf.
+	// Data in buf[0:r0] is considered to be discarded.
+	r0 int
+
+	// r1 holds the read position in buf. Data in buf[r1:] is
+	// next to be read. Data in buf[len(buf):cap(buf)] is
+	// available for reading into.
+	r1 int
+
+	// escBuf holds a buffer for unescaped characters.
+	escBuf []byte
+
+	// err holds any non-EOF error that was returned from rd.
+	err error
+}
 
 // NewTokenizer returns a tokenizer that splits the line-protocol text
 // inside buf. The text in buf represent a complete line (or multiple lines) - that
@@ -15,6 +54,7 @@ func NewTokenizerWithBytes(buf []byte) *Tokenizer {
 	return &Tokenizer{
 		buf:      buf,
 		complete: true,
+		escBuf:   make([]byte, 0, 512),
 	}
 }
 
@@ -24,74 +64,138 @@ func NewTokenizer(r io.Reader) *Tokenizer {
 	}
 }
 
-// Tokenizer implements low level parsing of a line-protocol message.
-type Tokenizer struct {
-	// rd holds the reader, if any. If there is no reader,
-	// complete will be true.
-	rd io.Reader
-
-	// buf holds read data.
-	buf []byte
-
-	// complete holds whether the data in buffer
-	// is known to be all the data that's available.
-	complete bool
-
-	// r holds the read position in buf.
-	r int
-
-	// err holds any non-EOF error that was returned from rd.
-	err error
-}
-
-// take returns the next slice of bytes within t.buf that are in the given set
-// starting at t.r + from, reading more data as needed.
-//
-// It does not update t.r.
-func (t *Tokenizer) take(set *byteSet, from int) []byte {
-	n := from
+// take returns the next slice of bytes that are in the given set
+// reading more data as needed. It updates t.r1.
+func (t *Tokenizer) take(set *byteSet) []byte {
+	// Note: use a relative index for start because absolute
+	// indexes aren't stable (the contents of the buffer can be
+	// moved when reading more data).
+	start := t.r1 - t.r0
 outer:
 	for {
-		if !t.ensure(n + 1) {
+		if !t.ensure(1) {
 			break
 		}
-		buf := t.buf[t.r+n:]
+		buf := t.buf[t.r1:]
 		for i, c := range buf {
 			if !set.get(c) {
-				n += i
+				t.r1 += i
 				break outer
 			}
 		}
-		n += len(buf)
+		t.r1 += len(buf)
 	}
-	return t.buf[t.r+from : t.r+n]
+	return t.buf[t.r0+start : t.r1]
+}
+
+// takeEsc is like take except that escaped characters also count as
+// part of the set. The escapeTable determines which characters
+// can be escaped.
+// It returns the unescaped string (unless t.skipping is true, in which
+// case it doesn't need to go to the trouble of unescaping it).
+func (t *Tokenizer) takeEsc(set *byteSet, escapeTable *[256]byte) []byte {
+	// start holds the offset from r0 of the start of the taken slice.
+	// Note that we can't use t.r1 directly, because the offsets can change
+	// when the buffer is grown.
+	start := t.r1 - t.r0
+
+	// startUnesc holds the offset from t0 of the start of the most recent
+	// unescaped segment.
+	startUnesc := start
+
+	// startEsc holds the index into r.escBuf of the start of the escape buffer.
+	startEsc := len(t.escBuf)
+outer:
+	for {
+		if !t.ensure(1) {
+			break
+		}
+		buf := t.buf[t.r1:]
+		for i := 0; i < len(buf); i++ {
+			c := buf[i]
+			if c != '\\' {
+				if !set.get(c) {
+					// We've found the end, so we're done here.
+					t.r1 += i
+					break outer
+				}
+				continue
+			}
+			if i+1 >= len(buf) {
+				// Not enough room in the buffer. Try reading more so that
+				// we can see the next byte (note: ensure(i+2) is asking
+				// for exactly one more character, because we know we already
+				// have i+1 bytes in the buffer).
+				if !t.ensure(i + 2) {
+					// No character to escape, so leave the \ intact.
+					t.r1 = len(t.buf)
+					break outer
+				}
+				// Note that t.ensure can change t.buf, so we need to
+				// update buf to point to the correct buffer.
+				buf = t.buf[t.r1:]
+			}
+			replc := escapeTable[buf[i+1]]
+			if replc == 0 {
+				// The backslash doesn't precede a value escaped
+				// character, so it stays intact.
+				continue
+			}
+			if !t.skipping {
+				t.escBuf = append(t.escBuf, t.buf[t.r0+startUnesc:t.r1+i]...)
+				t.escBuf = append(t.escBuf, replc)
+				startUnesc = t.r1 - t.r0 + i + 2
+			}
+			i++
+		}
+		// We've consumed all the bytes in the buffer. Now continue
+		// the loop, trying to acquire more.
+		t.r1 += len(buf)
+	}
+	if len(t.escBuf) > startEsc {
+		// We've got an unescaped result: append any remaining unescaped bytes
+		// and return the relevant portion of the escape buffer.
+		t.escBuf = append(t.escBuf, t.buf[startUnesc+t.r0:t.r1]...)
+		return t.escBuf[startEsc:]
+	}
+	return t.buf[t.r0+start : t.r1]
 }
 
 // at returns the byte at i bytes after the current read position.
-// It assumes that the byte has already been read (use t.ensure to check
-// whether it's there).
+// It assumes that the index has already been ensured.
+// If there's no byte there, it returns zero.
 func (t *Tokenizer) at(i int) byte {
-	return t.buf[t.r+i]
+	if t.r1+i < len(t.buf) {
+		return t.buf[t.r1+i]
+	}
+	return 0
 }
 
-// discard advances the read offset by n bytes.
-// There must be at least n bytes available in the buffer.
-func (t *Tokenizer) discard(n int) {
-	t.r += n
-	if t.r == len(t.buf) {
+// reset discards all the data up to t.r1 and data in t.escBuf
+func (t *Tokenizer) reset() {
+	if t.r1 == len(t.buf) {
 		// No bytes in the buffer, so we can start from the beginning without
 		// needing to copy anything (and get better cache behaviour too).
 		t.buf = t.buf[:0]
-		t.r = 0
+		t.r1 = 0
 	}
+	t.r0 = t.r1
+	t.escBuf = t.escBuf[:0]
+}
+
+// advance advances the read point by n.
+// This should only be used when it's known that
+// there are already n bytes available in the buffer.
+func (t *Tokenizer) advance(n int) {
+	t.r1 += n
 }
 
 // ensure ensures that there are at least n bytes available in
-// t.buf[t.r:], reading more bytes if necessary.
+// t.buf[t.r1:], reading more bytes if necessary.
 // It reports whether enough bytes are available.
 func (t *Tokenizer) ensure(n int) bool {
 	for {
-		if t.r+n <= len(t.buf) {
+		if t.r1+n <= len(t.buf) {
 			// There are enough bytes available.
 			return true
 		}
@@ -111,24 +215,28 @@ func (t *Tokenizer) readMore() {
 	n := cap(t.buf) - len(t.buf)
 	if n < minRead {
 		// There's not enough available space at the end of the buffer to read into.
-		if n+t.r >= minRead {
+		if t.r0+n >= minRead {
 			// There's enough space when we take into account already-used
 			// part of buf, so slide the data to the front.
-			copy(t.buf, t.buf[t.r:])
-			t.buf = t.buf[:len(t.buf)-t.r]
+			copy(t.buf, t.buf[t.r0:])
+			t.buf = t.buf[:len(t.buf)-t.r0]
+			t.r1 -= t.r0
+			t.r0 = 0
 		} else {
 			// We need to grow the buffer. Note that we don't have to copy
-			// the unused part of the buffer (t.buf[:t.r]).
+			// the unused part of the buffer (t.buf[:t.r0]).
 			// TODO provide a way to limit the maximum size that
 			// the buffer can grow to.
-			used := len(t.buf) - t.r
+			used := len(t.buf) - t.r0
 			n1 := cap(t.buf) * 2
-			if n1-used < minRead {
-				n1 = used + minRead
+			if n1-used < minGrow {
+				n1 = used + minGrow
 			}
 			buf1 := make([]byte, used, n1)
-			copy(buf1, t.buf[t.r:])
+			copy(buf1, t.buf[t.r0:])
 			t.buf = buf1
+			t.r1 -= t.r0
+			t.r0 = 0
 		}
 	}
 	n, err := t.rd.Read(t.buf[len(t.buf):cap(t.buf)])

--- a/influxdata/tokenizer_test.go
+++ b/influxdata/tokenizer_test.go
@@ -1,6 +1,7 @@
 package influxdata
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strings"
@@ -52,22 +53,18 @@ func TestTokenizerTake(t *testing.T) {
 		c.Run(test.testName, func(c *qt.C) {
 			s := "aabbcccddefga"
 			tok := test.newTokenizer(s)
-			data1 := tok.take(newByteSet('a', 'b', 'c'), 0)
+			data1 := tok.take(newByteSet('a', 'b', 'c'))
 			c.Assert(string(data1), qt.Equals, "aabbccc")
 
-			data2 := tok.take(newByteSet('d'), len(data1))
+			data2 := tok.take(newByteSet('d'))
 			c.Assert(string(data2), qt.Equals, "dd")
-			c.Assert(tok.r, qt.Equals, 0)
 
-			data3 := tok.take(newByteSet(' ').invert(), len(data1)+len(data2))
+			data3 := tok.take(newByteSet(' ').invert())
 			c.Assert(string(data3), qt.Equals, "efga")
 			c.Assert(tok.complete, qt.Equals, true)
 
-			data4 := tok.take(newByteSet(' ').invert(), len(data1)+len(data2)+len(data3))
+			data4 := tok.take(newByteSet(' ').invert())
 			c.Assert(string(data4), qt.Equals, "")
-
-			data5 := tok.take(newByteSet('a', 'b', 'c'), len(s))
-			c.Assert(string(data5), qt.Equals, "")
 
 			// Check that none of them have been overwritten.
 			c.Assert(string(data1), qt.Equals, "aabbccc")
@@ -82,18 +79,155 @@ func TestTokenizerTake(t *testing.T) {
 	}
 }
 
-func TestTokenizerTakeWithDiscard(t *testing.T) {
+func TestLongTake(t *testing.T) {
+	c := qt.New(t)
+	// Test that we can take segments that are longer than the
+	// read buffer size.
+	src := strings.Repeat("abcdefgh", (minRead*3)/8)
+	tok := NewTokenizer(strings.NewReader(src))
+	data := tok.take(newByteSet('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'))
+	c.Assert(string(data), qt.Equals, src)
+}
+
+func TestTakeWithReset(t *testing.T) {
+	c := qt.New(t)
+	// Test that we can take segments that are longer than the
+	// read buffer size.
+	lineCount := (minRead * 3) / 9
+	src := strings.Repeat("abcdefgh\n", lineCount)
+	tok := NewTokenizer(strings.NewReader(src))
+	n := 0
+	for {
+		data := tok.take(newByteSet('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'))
+		if len(data) == 0 {
+			break
+		}
+		n++
+		c.Assert(string(data), qt.Equals, "abcdefgh")
+		b := tok.at(0)
+		c.Assert(b, qt.Equals, byte('\n'))
+		tok.advance(1)
+		tok.reset()
+	}
+	c.Assert(n, qt.Equals, lineCount)
+}
+
+func TestTokenizerTakeWithReset(t *testing.T) {
 	c := qt.New(t)
 	// With a byte-at-a-time reader, we won't read any more
-	// than we absolutely need, so discard should cause the
-	// buffer to be overwritten each time.
+	// than we absolutely need.
 	tok := NewTokenizer(iotest.OneByteReader(strings.NewReader("aabbcccddefg")))
-	data1 := tok.take(newByteSet('a', 'b', 'c'), 0)
+	data1 := tok.take(newByteSet('a', 'b', 'c'))
 	c.Assert(string(data1), qt.Equals, "aabbccc")
-	tok.discard(len(data1))
 	c.Assert(tok.at(0), qt.Equals, byte('d'))
-	tok.discard(1)
-	c.Assert(tok.r, qt.Equals, 0)
+	tok.advance(1)
+	tok.reset()
+	c.Assert(tok.r0, qt.Equals, 0)
+	c.Assert(tok.r1, qt.Equals, 0)
+}
+
+func TestTokenizerTakeEsc(t *testing.T) {
+	c := qt.New(t)
+	for _, test := range tokenizerTakeTests {
+		c.Run(test.testName, func(c *qt.C) {
+			tok := test.newTokenizer(`hello\ \t\\z\XY`)
+			data := tok.takeEsc(newByteSet('X').invert(), &newEscaper(" \t").revTable)
+			c.Assert(string(data), qt.Equals, "hello \t\\\\z\\")
+
+			// Check that an escaped character will be included when
+			// it's not part of the take set.
+			tok = test.newTokenizer(`hello\ \t\\z\XYX`)
+			data1 := tok.takeEsc(newByteSet('X').invert(), &newEscaper("X \t").revTable)
+			c.Assert(string(data1), qt.Equals, "hello \t\\\\zXY")
+
+			// Check that the next call to takeEsc continues where it left off.
+			data2 := tok.takeEsc(newByteSet(' ').invert(), &newEscaper(" ").revTable)
+			c.Assert(string(data2), qt.Equals, "X")
+			// Check that data1 hasn't been overwritten.
+			c.Assert(string(data1), qt.Equals, "hello \t\\\\zXY")
+
+			// Check that a backslash followed by EOF is taken as literal.
+			tok = test.newTokenizer(`x\`)
+			data = tok.takeEsc(newByteSet().invert(), &newEscaper(" ").revTable)
+			c.Assert(string(data), qt.Equals, "x\\")
+		})
+	}
+}
+
+func TestTokenizerTakeEscSkipping(t *testing.T) {
+	c := qt.New(t)
+	tok := NewTokenizer(strings.NewReader(`hello\ \t\\z\XY`))
+	tok.skipping = true
+	data := tok.takeEsc(newByteSet('X').invert(), &newEscaper(" \t").revTable)
+	// When skipping is true, the data isn't unquoted (that's just unnecessary extra work).
+	c.Assert(string(data), qt.Equals, `hello\ \t\\z\`)
+}
+
+func TestTokenizerTakeEscGrowBuffer(t *testing.T) {
+	// This test tests the code path in Tokenizer.readMore
+	// when the buffer needs to grow while we're reading a token.
+	c := qt.New(t)
+	tok := NewTokenizer(&nbyteReader{
+		buf: []byte(`hello\ \ \ \  foo`),
+		next: []int{
+			len(`hello\`),
+			len(` \ \ \`),
+			len(`  foo`),
+		},
+	})
+	data := tok.takeEsc(newByteSet(' ').invert(), &newEscaper(" ").revTable)
+	c.Assert(string(data), qt.Equals, `hello    `)
+	data = tok.take(newByteSet().invert())
+	c.Assert(string(data), qt.Equals, ` foo`)
+}
+
+func TestTokenizerTakeSlideBuffer(t *testing.T) {
+	// This test tests the code path in Tokenizer.readMore
+	// when the read buffer is large enough but the current
+	// data is inconveniently in the wrong place, so
+	// it gets slid to the front of the buffer.
+	c := qt.New(t)
+	// The first string that we'll read takes up almost all of the
+	// initially added buffer, leaving just a little left at the end,
+	// that will be moved to the front when we come to read that part.
+	firstToken := strings.Repeat("a", minGrow-4)
+	tok := NewTokenizer(strings.NewReader(firstToken + ` helloworld there`))
+	data := tok.take(newByteSet(' ').invert())
+	c.Assert(string(data), qt.Equals, firstToken)
+	data = tok.take(newByteSet(' '))
+	c.Assert(string(data), qt.Equals, " ")
+
+	// Reset the buffer. There's still the data from `helloworld` onwards that will remain in the buffer.
+	tok.reset()
+
+	data = tok.take(newByteSet(' ').invert())
+	c.Assert(string(data), qt.Equals, "helloworld")
+	data = tok.take(newByteSet(' '))
+	c.Assert(string(data), qt.Equals, " ")
+	data = tok.take(newByteSet(' ').invert())
+	c.Assert(string(data), qt.Equals, "there")
+}
+
+type nbyteReader struct {
+	// next holds the read counts for subsequent calls to Read.
+	// If next is empty and buf is not empty, Read will panic.
+	next []int
+	// buf holds the data remaining to be read.
+	buf []byte
+}
+
+func (r *nbyteReader) Read(buf []byte) (int, error) {
+	if len(r.buf) == 0 && len(r.next) == 0 {
+		return 0, io.EOF
+	}
+	n := r.next[0]
+	r.next = r.next[1:]
+	nb := copy(buf, r.buf[:n])
+	if nb != n {
+		panic(fmt.Errorf("read count for return (%d) is too large for provided buffer (%d)", n, len(r.buf)))
+	}
+	r.buf = r.buf[n:]
+	return n, nil
 }
 
 type errorReader struct {
@@ -107,4 +241,57 @@ func (r *errorReader) Read(buf []byte) (int, error) {
 		err = r.err
 	}
 	return n, err
+}
+
+func BenchmarkTokenize(b *testing.B) {
+	var buf bytes.Buffer
+	b.ReportAllocs()
+	total := 0
+	for buf.Len() < 25*1024*1024 {
+		buf.WriteString("foo ba\\ rfle ")
+		for i := 0; i < 5000; i += 5 {
+			buf.WriteString("abcde")
+		}
+		buf.WriteByte('\n')
+		total++
+	}
+	b.SetBytes(int64(buf.Len()))
+	esc := newEscaper(" \t")
+	whitespace := newByteSet(' ', '\t')
+	word := newByteSet(' ', '\t', '\n').invert()
+	tokBytes := buf.Bytes()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		n := 0
+		tok := NewTokenizerWithBytes(tokBytes)
+		for {
+			tok.reset()
+			if !tok.ensure(1) {
+				break
+			}
+			tok.takeEsc(word, &esc.revTable)
+			tok.take(whitespace)
+			if !tok.ensure(1) {
+				break
+			}
+			tok.takeEsc(word, &esc.revTable)
+			tok.take(whitespace)
+			if !tok.ensure(1) {
+				break
+			}
+			tok.takeEsc(word, &esc.revTable)
+			tok.take(whitespace)
+			if !tok.ensure(1) {
+				break
+			}
+			if tok.at(0) != '\n' {
+				b.Fatalf("unexpected character %q at eol", string(rune(tok.at(0))))
+			}
+			tok.advance(1)
+			n++
+		}
+		if n != total {
+			b.Fatalf("unexpected read count; got %v want %v", n, total)
+		}
+	}
 }


### PR DESCRIPTION
This is used to tokenize escapable strings.

Testing is still on the light side - the plan is to bootstrap
with these low level primitives, then add much more comprehensive
tests at the top level.