### PR TITLE
fix: Encode not returning error and counting written bytes wrong

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -169,7 +169,11 @@ func (e *Encoder) Encode(m Metric) (int, error) {
 
 		}
 
-		e.w.Write(e.pair)
+		i, err = e.w.Write(e.pair)
+		if err != nil {
+			return 0, err
+		}
+		totalWritten += i
 
 		pairsLen += len(e.pair)
 		firstField = false

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -540,9 +540,12 @@ func TestEncoder(t *testing.T) {
 			serializer.SetFieldTypeSupport(tt.typeSupport)
 			serializer.FailOnFieldErr(tt.failOnFieldErr)
 			serializer.SetPrecision(tt.precision)
-			_, err := serializer.Encode(tt.input)
+			i, err := serializer.Encode(tt.input)
 			if tt.err != err {
 				t.Fatalf("expected error %v, but got %v", tt.err, err)
+			}
+			if i != len(buf.Bytes()) {
+				t.Fatalf("expected i: %v, but got: %v", len(buf.Bytes()), i)
 			}
 			if string(tt.output) != buf.String() {
 				t.Fatalf("expected output %v, but got %v", tt.output, buf.String())


### PR DESCRIPTION
Fix Encode not returning error if failed to e.w.Write(e.pair).

Now Encode counts written bytes properly.
Added test for that.