### PR TITLE
influxdata: add Value and test against line-protocol corpus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/influxdata/line-protocol
 
 go 1.15
 
-require github.com/frankban/quicktest v1.11.0
+require (
+	github.com/frankban/quicktest v1.11.0
+	github.com/google/go-cmp v0.5.2
+)

--- a/influxdata/byteset.go
+++ b/influxdata/byteset.go
@@ -1,15 +1,5 @@
 package influxdata
 
-import (
-	"fmt"
-	"strings"
-)
-
-// save these methods from staticcheck. we're going to use them later.
-var (
-	_ = (*byteSet).intersect
-)
-
 // newByteset returns a set representation
 // of the bytes in the given string.
 func newByteSet(s string) *byteSet {
@@ -18,20 +8,6 @@ func newByteSet(s string) *byteSet {
 		set.set(s[i])
 	}
 	return &set
-}
-
-func (b *byteSet) String() string {
-	var buf strings.Builder
-	for i := 0; i < 256; i++ {
-		if b.get(byte(i)) {
-			buf.WriteByte(byte(i))
-		}
-	}
-	s := buf.String()
-	if len(s) > 128 {
-		return fmt.Sprintf("not(%v)", b.invert())
-	}
-	return fmt.Sprintf("%q", s)
 }
 
 // TODO benchmark it. This is compact (good cache behaviour)
@@ -53,15 +29,6 @@ func (b *byteSet) union(b1 *byteSet) *byteSet {
 	r := *b
 	for i := range r {
 		r[i] |= b1[i]
-	}
-	return &r
-}
-
-// intersect returns the intersection of b and b1.
-func (b *byteSet) intersect(b1 *byteSet) *byteSet {
-	r := *b
-	for i := range r {
-		r[i] &= b1[i]
 	}
 	return &r
 }

--- a/influxdata/corpus_test.go
+++ b/influxdata/corpus_test.go
@@ -1,0 +1,324 @@
+package influxdata
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+// corpusAllowList lists the test cases that have been explicitly checked and
+// all the current implementations are wrong.
+var corpusAllowList = map[string]string{
+	"4e8bcb126274d3290789538902dab6ee": "no trailing backslash",
+}
+
+func TestCorpus(t *testing.T) {
+	c := qt.New(t)
+	corpus, err := readCorpus()
+	c.Assert(err, qt.IsNil)
+	for _, test := range corpus {
+		c.Run(test.Input.Key, func(c *qt.C) {
+			m, err := tokenizeToCorpusMetrics(test.Input.Text, test.Input.Precision, test.Input.DefaultTime)
+			// We'll treat it as success if we match any of the result
+			ok := false
+			validResults := 0
+			for impl, out := range test.Output {
+				if impl == "delorean" {
+					// Ignore delorean results because they're screwy.
+					continue
+				}
+				if strings.HasPrefix(out.Error, "crash: ") {
+					// A crash is not a valid result.
+					continue
+				}
+				validResults++
+				if out.Error != "" {
+					ok = ok || err != nil
+					continue
+				}
+				ok = ok || cmp.Equal(m, out.Result, cmpopts.EquateEmpty())
+			}
+			allowListReason := corpusAllowList[test.Input.Key]
+			if ok {
+				if allowListReason != "" {
+					c.Errorf("unexpected success on allowListed corpus test")
+				}
+				return
+			}
+			if hasBackslashVIssue(test.Input.Text) {
+				allowListReason = "leading char-\\v ignored"
+			}
+			if allowListReason != "" {
+				c.Skipf("test has been explicitly marked for success (reason: %s)", allowListReason)
+			}
+			if validResults == 0 {
+				c.Errorf("no implementation produced a valid result")
+				return
+			}
+			if err != nil {
+				c.Errorf("all implementations succeeded but Tokenize failed with error: %v", err)
+				return
+			}
+			c.Errorf("result doesn't match any implementation")
+			data, _ := json.MarshalIndent(m, "\t", "\t")
+			c.Logf("%s", data)
+		})
+	}
+}
+
+func hasBackslashVIssue(s []byte) bool {
+	if len(s) > 2 && s[1] == '\v' {
+		return true
+	}
+	for ; len(s) > 3; s = s[1:] {
+		if s[0] == '\n' && s[2] == '\v' {
+			return true
+		}
+	}
+	return false
+}
+
+func tokenizeToCorpusMetrics(text []byte, precision string, defaultTime int64) ([]*corpusMetric, error) {
+	tok := NewTokenizerWithBytes(text)
+	ms := []*corpusMetric{}
+	for tok.Next() {
+		m, err := tokenizeToCorpusMetric(tok, precision, defaultTime)
+		if err != nil {
+			return nil, fmt.Errorf("cannot get metric %v: %v", len(ms), err)
+		}
+		ms = append(ms, m)
+	}
+	return ms, nil
+}
+
+func tokenizeToCorpusMetric(tok *Tokenizer, precision string, defaultTime int64) (*corpusMetric, error) {
+	var m corpusMetric
+	var err error
+	m.Name, err = tok.Measurement()
+	if err != nil {
+		return nil, fmt.Errorf("cannot get measurement: %v", err)
+	}
+	for {
+		key, val, err := tok.NextTag()
+		if err != nil {
+			return nil, fmt.Errorf("cannot get tag %v: %v", len(m.Tags), err)
+		}
+		if key == nil {
+			break
+		}
+		m.Tags = append(m.Tags, corpusTag{
+			Key:   dupBytes(key),
+			Value: dupBytes(val),
+		})
+	}
+	sort.Slice(m.Tags, func(i, j int) bool {
+		return bytes.Compare(m.Tags[i].Key, m.Tags[j].Key) < 0
+	})
+	for i := range m.Tags {
+		if i > 0 && bytes.Equal(m.Tags[i-1].Key, m.Tags[i].Key) {
+			return nil, fmt.Errorf("duplicate key %q", m.Tags[i].Key)
+		}
+	}
+	for {
+		key, val, err := tok.NextField()
+		if err != nil {
+			return nil, fmt.Errorf("cannot get field %d: %v", len(m.Fields), err)
+		}
+		if key == nil {
+			break
+		}
+		field := corpusField{
+			Key: dupBytes(key),
+		}
+		switch val.Kind() {
+		case Int:
+			x := val.IntV()
+			field.Value.Int = &x
+		case Uint:
+			x := val.UintV()
+			field.Value.Uint = &x
+		case Bool:
+			x := val.BoolV()
+			field.Value.Bool = &x
+		case Float:
+			x := val.FloatV()
+			field.Value.Float = &x
+		case String:
+			x := val.StringV()
+			field.Value.String = &x
+		default:
+			panic(fmt.Errorf("unknown value kind %v", val))
+		}
+		m.Fields = append(m.Fields, field)
+	}
+	var p Precision
+	switch precision {
+	case "1ns":
+		p = Nanosecond
+	case "1µs":
+		p = Microsecond
+	case "1ms":
+		p = Millisecond
+	case "1s":
+		p = Second
+	default:
+		panic(fmt.Errorf("unknown precision in test corpus %q", precision))
+	}
+	timestamp, err := tok.Time(p, time.Unix(0, defaultTime))
+	if err != nil {
+		return nil, fmt.Errorf("cannot get time: %v", err)
+	}
+	m.Time = timestamp.UnixNano()
+	return &m, nil
+}
+
+func dupBytes(b []byte) []byte {
+	return append([]byte(nil), b...)
+}
+
+// unused but we'd like to keep around, so pacify staticcheck.
+var _ = fromCorpusValue
+
+func fromCorpusValue(v corpusValue) (Value, error) {
+	switch {
+	case v.Int != nil:
+		return MustNewValue(*v.Int), nil
+	case v.Uint != nil:
+		return MustNewValue(*v.Uint), nil
+	case v.Float != nil:
+		return MustNewValue(*v.Float), nil
+	case v.Bool != nil:
+		return MustNewValue(*v.Bool), nil
+	case v.String != nil:
+		return MustNewValue(*v.String), nil
+	case v.Binary != nil:
+		return Value{}, fmt.Errorf("non-utf8 values not supported")
+	case v.FloatNonNumber != nil:
+		return Value{}, fmt.Errorf("non-numeric float values not supported")
+	default:
+		return Value{}, fmt.Errorf("unknown corpus value kind %#v", v)
+	}
+}
+
+func readCorpus() ([]*corpusDecodeResults, error) {
+	const corpusFile = "testdata/corpus-results.json"
+	data, err := ioutil.ReadFile(corpusFile)
+	if err != nil {
+		return nil, err
+	}
+	var r corpusResults
+	if err := json.Unmarshal(data, &r); err != nil {
+		if terr, ok := err.(*json.UnmarshalTypeError); ok {
+			return nil, fmt.Errorf("unmarshal error at %s:#%d: %v", corpusFile, terr.Offset, err)
+		}
+		return nil, fmt.Errorf("unmarshal error at %s: %v", corpusFile, err)
+	}
+	// Return a slice rather than the map so that
+	// it's easy to execute the tests in deterministic order.
+	rs := make([]*corpusDecodeResults, 0, len(r.Decode))
+	for _, d := range r.Decode {
+		rs = append(rs, d)
+	}
+	sort.Slice(rs, func(i, j int) bool {
+		return rs[i].Input.Key < rs[j].Input.Key
+	})
+	return rs, nil
+}
+
+type corpusResults struct {
+	Decode map[string]*corpusDecodeResults `json:"decode,omitempty"`
+	// TODO include encode results too when we've got an encoder.
+}
+
+type corpusDecodeResults struct {
+	Input  *corpusDecodeInput             `json:"input"`
+	Output map[string]*corpusDecodeOutput `json:"output"`
+}
+
+type corpusDecodeInput struct {
+	Key         string      `json:"key"`
+	Text        corpusBytes `json:"text"`
+	DefaultTime int64       `json:"defaultTime"`
+	Precision   string      `json:"precision"`
+}
+
+type corpusDecodeOutput struct {
+	Result []*corpusMetric `json:"result,omitempty"`
+	Error  string          `json:"error,omitempty"`
+}
+
+type corpusMetric struct {
+	Time   int64         `json:"time"`
+	Name   corpusBytes   `json:"name"`
+	Tags   []corpusTag   `json:"tags,omitempty"`
+	Fields []corpusField `json:"fields,omitempty"`
+}
+
+type corpusField struct {
+	Key   corpusBytes `json:"key"`
+	Value corpusValue `json:"value"`
+}
+
+type corpusTag struct {
+	Key   corpusBytes `json:"key"`
+	Value corpusBytes `json:"value"`
+}
+
+type corpusValue struct {
+	Int            *int64   `json:"int,omitempty"`
+	Uint           *uint64  `json:"uint,omitempty"`
+	Float          *float64 `json:"float,omitempty"`
+	FloatNonNumber *string  `json:"floatNonNumber,omitempty"`
+	Bool           *bool    `json:"bool,omitempty"`
+	String         *string  `json:"string,omitempty"`
+	Binary         *string  `json:"binary,omitempty"`
+}
+
+// corpusBytes  implements a byte slice that knows how to marshal itself into
+// and out of JSON while preserving raw-byte integrity.
+type corpusBytes []byte
+
+type base64Str struct {
+	Binary string `yaml:"binary" json:"binary"`
+}
+
+func (b corpusBytes) MarshalJSON() ([]byte, error) {
+	if utf8.Valid(b) {
+		return json.Marshal(string(b))
+	}
+	return json.Marshal(base64Str{
+		Binary: base64.StdEncoding.EncodeToString(b),
+	})
+}
+
+func (b *corpusBytes) UnmarshalJSON(data []byte) error {
+	if data[0] == '{' {
+		var bstr base64Str
+		if err := json.Unmarshal(data, &bstr); err != nil {
+			return err
+		}
+		dec, err := base64.StdEncoding.DecodeString(bstr.Binary)
+		if err != nil {
+			return fmt.Errorf("cannot decode binary base64 value: %v", err)
+		}
+		*b = dec
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	*b = []byte(s)
+	return nil
+}

--- a/influxdata/precision.go
+++ b/influxdata/precision.go
@@ -1,0 +1,62 @@
+package influxdata
+
+import (
+	"fmt"
+	"time"
+)
+
+// Precision specifies the scale at which a line-protocol timestamp
+// is encoded.
+type Precision byte
+
+const (
+	Nanosecond Precision = iota
+	Microsecond
+	Millisecond
+	Second
+)
+
+// asNanoseconds returns x multiplied by p.Duration.
+// It reports whether the multiplication succeeded without
+// overflow.
+func (p Precision) asNanoseconds(x int64) (int64, bool) {
+	if p == Nanosecond {
+		return x, true
+	}
+	d := int64(p.Duration())
+	// Note: because p has a limited number of values, we don't have
+	// to worry about edge cases like x being the most negative number.
+	if c := x * d; c/d == x {
+		return c, true
+	}
+	return 0, false
+}
+
+// Duration returns the time duration for the given precision.
+func (p Precision) Duration() time.Duration {
+	switch p {
+	case Nanosecond:
+		return time.Nanosecond
+	case Microsecond:
+		return time.Microsecond
+	case Millisecond:
+		return time.Millisecond
+	case Second:
+		return time.Second
+	}
+	panic(fmt.Errorf("unknown precision %d", p))
+}
+
+func (p Precision) String() string {
+	switch p {
+	case Nanosecond:
+		return "ns"
+	case Microsecond:
+		return "µs"
+	case Millisecond:
+		return "ms"
+	case Second:
+		return "s"
+	}
+	panic(fmt.Errorf("unknown precision %d", p))
+}

--- a/influxdata/strconv.go
+++ b/influxdata/strconv.go
@@ -1,0 +1,49 @@
+package influxdata
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"unsafe"
+)
+
+// parseIntBytes is a zero-alloc wrapper around strconv.ParseInt.
+func parseIntBytes(b []byte, base int, bitSize int) (i int64, err error) {
+	return strconv.ParseInt(unsafeBytesToString(b), base, bitSize)
+}
+
+// parseUintBytes is a zero-alloc wrapper around strconv.ParseUint.
+func parseUintBytes(b []byte, base int, bitSize int) (i uint64, err error) {
+	return strconv.ParseUint(unsafeBytesToString(b), base, bitSize)
+}
+
+// parseFloatBytes is a zero-alloc wrapper around strconv.ParseFloat.
+func parseFloatBytes(b []byte, bitSize int) (float64, error) {
+	return strconv.ParseFloat(unsafeBytesToString(b), bitSize)
+}
+
+var errInvalidBool = fmt.Errorf("invalid boolean value")
+
+// parseBoolBytes doesn't bother wrapping strconv.ParseBool because
+// it's not quite the same, so simple and faster this way.
+func parseBoolBytes(s []byte) (byte, error) {
+	switch string(s) {
+	case "t", "T", "true", "True", "TRUE":
+		return 1, nil
+	case "f", "F", "false", "False", "FALSE":
+		return 0, nil
+	}
+	return 0, errInvalidBool
+}
+
+// unsafeBytesToString converts a []byte to a string without a heap allocation.
+//
+// It is unsafe, and is intended to prepare input to short-lived functions
+// that require strings.
+func unsafeBytesToString(data []byte) string {
+	dataHeader := *(*reflect.SliceHeader)(unsafe.Pointer(&data))
+	return *(*string)(unsafe.Pointer(&reflect.StringHeader{
+		Data: dataHeader.Data,
+		Len:  dataHeader.Len,
+	}))
+}

--- a/influxdata/value.go
+++ b/influxdata/value.go
@@ -1,0 +1,254 @@
+package influxdata
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+)
+
+// Value holds one of the possible line-protocol field values.
+type Value struct {
+	// number covers:
+	//	- signed integer
+	//	- unsigned integer
+	//	- bool
+	//	- float
+	number uint64
+	// bytes holds the string bytes or a sentinel (see below)
+	// when the value's not holding a string.
+	bytes []byte
+}
+
+var (
+	intSentinel   = [1]byte{'i'}
+	uintSentinel  = [1]byte{'u'}
+	floatSentinel = [1]byte{'f'}
+	boolSentinel  = [1]byte{'b'}
+)
+
+func MustNewValue(x interface{}) Value {
+	v, ok := NewValue(x)
+	if !ok {
+		panic(fmt.Errorf("invalid value for NewValue: %T (%#v)", x, x))
+	}
+	return v
+}
+
+func (v1 Value) Equal(v2 Value) bool {
+	return v1.Kind() == v2.Kind() && v1.number == v2.number && bytes.Equal(v1.bytes, v2.bytes)
+}
+
+// ParseValue parses the data as a value of the given kind.
+//
+// The data for Int and Uint kinds should not include
+// the type suffixes present in the line-protocol field values.
+// For example, the data for the zero Int should be "0" not "0i".
+//
+// If kind is String, the returned value still refers to the data
+// slice: it does not make a copy.
+func ParseValue(kind ValueKind, data []byte) (Value, error) {
+	switch kind {
+	case Int:
+		x, err := parseIntBytes(data, 10, 64)
+		if err != nil {
+			return Value{}, fmt.Errorf("invalid integer value %q", data)
+		}
+		return Value{
+			number: uint64(x),
+			bytes:  intSentinel[:],
+		}, nil
+	case Uint:
+		x, err := parseUintBytes(data, 10, 64)
+		if err != nil {
+			return Value{}, fmt.Errorf("invalid unsigned integer value %q", data)
+		}
+		return Value{
+			number: x,
+			bytes:  uintSentinel[:],
+		}, nil
+	case Float:
+		x, err := parseFloatBytes(data, 64)
+		if err != nil {
+			return Value{}, fmt.Errorf("invalid float value %q", data)
+		}
+		if math.IsInf(x, 0) || math.IsNaN(x) {
+			return Value{}, fmt.Errorf("non-number %q cannot be represented as a line-protocol field value", data)
+		}
+		return Value{
+			number: math.Float64bits(x),
+			bytes:  floatSentinel[:],
+		}, nil
+	case Bool:
+		x, err := parseBoolBytes(data)
+		if err != nil {
+			return Value{}, fmt.Errorf("invalid bool value %q", data)
+		}
+		return Value{
+			number: uint64(x),
+			bytes:  boolSentinel[:],
+		}, nil
+	case String:
+		// TODO check that it's valid utf-8 data?
+		return Value{
+			bytes: data,
+		}, nil
+	case Unknown:
+		return Value{}, fmt.Errorf("cannot parse value %q with unknown kind", data)
+	default:
+		return Value{}, fmt.Errorf("unexpected value kind %d (value %q)", kind, data)
+	}
+}
+
+// NewValue returns a Value containing the value of x, which must
+// be of type int64 (Int), uint64 (Uint), float64 (Float), bool (Bool),
+// string (String) or []byte (String).
+//
+// Unlike ParseValue, NewValue will make a copy of the byte
+// slice if x is []byte - use ParseValue if you require zero-copy
+// semantics.
+func NewValue(x interface{}) (Value, bool) {
+	switch x := x.(type) {
+	case int64:
+		return Value{
+			number: uint64(x),
+			bytes:  intSentinel[:],
+		}, true
+	case uint64:
+		return Value{
+			number: uint64(x),
+			bytes:  uintSentinel[:],
+		}, true
+	case float64:
+		if math.IsInf(x, 0) || math.IsNaN(x) {
+			return Value{}, false
+		}
+		return Value{
+			number: math.Float64bits(x),
+			bytes:  floatSentinel[:],
+		}, true
+	case bool:
+		n := uint64(0)
+		if x {
+			n = 1
+		}
+		return Value{
+			number: uint64(n),
+			bytes:  boolSentinel[:],
+		}, true
+	case string:
+		return Value{
+			bytes: []byte(x),
+		}, true
+	case []byte:
+		return Value{
+			bytes: append([]byte(nil), x...),
+		}, true
+	}
+	return Value{}, false
+}
+
+// IntV returns the value as an int64. It panics if v.Kind is not Int.
+func (v Value) IntV() int64 {
+	v.mustBe(Int)
+	return int64(v.number)
+}
+
+// UintV returns the value as a uint64. It panics if v.Kind is not Uint.
+func (v Value) UintV() uint64 {
+	v.mustBe(Uint)
+	return v.number
+}
+
+// FloatV returns the value as a float64. It panics if v.Kind is not Float.
+func (v Value) FloatV() float64 {
+	v.mustBe(Float)
+	return math.Float64frombits(v.number)
+}
+
+// StringV returns the value as a string. It panics if v.Kind is not String.
+func (v Value) StringV() string {
+	v.mustBe(String)
+	return string(v.bytes)
+}
+
+// BytesV returns the value as a []byte. It panics if v.Kind is not String.
+// Note that this may return a direct reference to the byte slice within the
+// value - modifying the returned byte slice may mutate the contents
+// of the Value.
+func (v Value) BytesV() []byte {
+	v.mustBe(String)
+	return v.bytes
+}
+
+// BoolV returns the value as a bool. It panics if v.Kind is not Bool.
+func (v Value) BoolV() bool {
+	v.mustBe(Bool)
+	return v.number != 0
+}
+
+// Interface returns the value as an interface. The returned value
+// will have a different dynamic type depending on the value kind;
+// one of int64 (Int), uint64 (Uint), float64 (Float), string (String), bool (Bool).
+func (v Value) Interface() interface{} {
+	switch v.Kind() {
+	case Int:
+		return v.IntV()
+	case Uint:
+		return v.UintV()
+	case String:
+		return v.StringV()
+	case Bool:
+		return v.BoolV()
+	case Float:
+		return v.FloatV()
+	default:
+		// Shouldn't be able to happen.
+		panic("unknown value kind")
+	}
+}
+
+func (v Value) mustBe(k ValueKind) {
+	if v.Kind() != k {
+		panic(fmt.Errorf("value has unexpected kind; got %v want %v", v.Kind(), k))
+	}
+}
+
+func (v Value) Kind() ValueKind {
+	if len(v.bytes) != 1 {
+		return String
+	}
+	switch &v.bytes[0] {
+	case &intSentinel[0]:
+		return Int
+	case &uintSentinel[0]:
+		return Uint
+	case &floatSentinel[0]:
+		return Float
+	case &boolSentinel[0]:
+		return Bool
+	}
+	return String
+}
+
+// String returns the value similarly to how it would appear
+// in a line-protocol entry, except that strings are quoted
+// according to Go rules not line-protocol rules.
+func (v Value) String() string {
+	switch v.Kind() {
+	case Float:
+		return fmt.Sprint(v.FloatV())
+	case Int:
+		return fmt.Sprintf("%di", v.IntV())
+	case Uint:
+		return fmt.Sprintf("%du", v.UintV())
+	case Bool:
+		if v.BoolV() {
+			return "true"
+		}
+		return "false"
+	case String:
+		return fmt.Sprintf("%q", v.StringV())
+	default:
+		panic("unknown kind")
+	}
+}

--- a/influxdata/value_test.go
+++ b/influxdata/value_test.go
@@ -1,0 +1,153 @@
+package influxdata
+
+import (
+	"math"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+var parseValueTests = []struct {
+	testName        string
+	kind            ValueKind
+	data            string
+	expectError     string
+	expectInterface interface{}
+	expectString    string
+}{{
+	testName:        "int",
+	kind:            Int,
+	data:            "1234",
+	expectInterface: int64(1234),
+	expectString:    "1234i",
+}, {
+	testName:        "uint",
+	kind:            Uint,
+	data:            "1234",
+	expectInterface: uint64(1234),
+	expectString:    "1234u",
+}, {
+	testName:        "float",
+	kind:            Float,
+	data:            "1e3",
+	expectInterface: float64(1000),
+	expectString:    "1000",
+}, {
+	testName:        "bool-true",
+	kind:            Bool,
+	data:            "true",
+	expectInterface: true,
+	expectString:    "true",
+}, {
+	testName:        "bool-false",
+	kind:            Bool,
+	data:            "false",
+	expectInterface: false,
+	expectString:    "false",
+}, {
+	testName:        "string",
+	kind:            String,
+	data:            "hello world",
+	expectInterface: "hello world",
+	expectString:    `"hello world"`,
+}, {
+	testName:    "invalid-int",
+	kind:        Int,
+	data:        "1e3",
+	expectError: `invalid integer value "1e3"`,
+}, {
+	testName:    "invalid-uint",
+	kind:        Uint,
+	data:        "1e3",
+	expectError: `invalid unsigned integer value "1e3"`,
+}, {
+	testName:    "invalid-float",
+	kind:        Float,
+	data:        "1e3a",
+	expectError: `invalid float value "1e3a"`,
+}, {
+	testName:    "NaN",
+	kind:        Float,
+	data:        "NaN",
+	expectError: `non-number "NaN" cannot be represented as a line-protocol field value`,
+}, {
+	testName:    "-Inf",
+	kind:        Float,
+	data:        "-Inf",
+	expectError: `non-number "-Inf" cannot be represented as a line-protocol field value`,
+}, {
+	testName:    "invalid-bool",
+	kind:        Bool,
+	data:        "truE",
+	expectError: `invalid bool value "truE"`,
+}, {
+	testName:    "unknown-kind",
+	kind:        Unknown,
+	data:        "nope",
+	expectError: `cannot parse value "nope" with unknown kind`,
+}, {
+	testName:    "invalid-kind",
+	kind:        125,
+	data:        "nope",
+	expectError: `unexpected value kind 125 \(value "nope"\)`,
+}}
+
+func TestValueCreation(t *testing.T) {
+	c := qt.New(t)
+	for _, test := range parseValueTests {
+		c.Run(test.testName, func(c *qt.C) {
+			v, err := ParseValue(test.kind, []byte(test.data))
+			if test.expectError != "" {
+				c.Assert(err, qt.ErrorMatches, test.expectError)
+			} else {
+				c.Assert(v.Kind(), qt.Equals, test.kind)
+				c.Assert(v.Interface(), qt.Equals, test.expectInterface)
+				c.Assert(v.String(), qt.Equals, test.expectString)
+
+				// Check that we can create the same value with NewValue
+				v1, ok := NewValue(v.Interface())
+				c.Assert(ok, qt.IsTrue)
+				c.Assert(v1.Kind(), qt.Equals, v.Kind())
+				c.Assert(v1, qt.DeepEquals, v)
+				c.Assert(v1.Interface(), qt.Equals, v.Interface())
+				v2 := MustNewValue(v.Interface())
+				c.Assert(v2, qt.DeepEquals, v1)
+				if test.kind == String {
+					// Check we can use bytes values too.
+					v3, ok := NewValue(v.BytesV())
+					c.Assert(ok, qt.IsTrue)
+					c.Assert(v3.Kind(), qt.Equals, v.Kind())
+					c.Assert(v3, qt.DeepEquals, v)
+					c.Assert(v3.Interface(), qt.Equals, v.Interface())
+				}
+			}
+		})
+	}
+}
+
+// Note: many NewValue inputs are tested in TestValueCreation above.
+// This test just tests values that can be represented as Go values
+// but not as valid Values.
+var newValueInvalidTests = []struct {
+	testName string
+	value    interface{}
+}{{
+	testName: "NaN",
+	value:    math.NaN(),
+}, {
+	testName: "Inf",
+	value:    math.Inf(1),
+}, {
+	testName: "unknown-type",
+	value:    new(int),
+}}
+
+func TestNewValueInvalid(t *testing.T) {
+	c := qt.New(t)
+	for _, test := range newValueInvalidTests {
+		c.Run(test.testName, func(c *qt.C) {
+			_, ok := NewValue(test.value)
+			c.Assert(ok, qt.IsFalse)
+		})
+	}
+}


### PR DESCRIPTION
The Value type enables us to return field values without incurring
allocation overhead. With this in place, we're able to run the tests
against all the tests in the line-protocol corpus repository.  Because
there's no good definition of "correct" yet, we define a result to be
correct if it matches the result from at least one current implementation.
