### PR TITLE
influxdata: add benchmark for top level tokenizing methods

### DIFF
--- a/influxdata/byteset.go
+++ b/influxdata/byteset.go
@@ -10,25 +10,23 @@ func newByteSet(s string) *byteSet {
 	return &set
 }
 
-// TODO benchmark it. This is compact (good cache behaviour)
-// but maybe [256]bool might be faster (less operations).
-type byteSet [4]uint64
+type byteSet [256]bool
 
-// get reports whether b holds the byte x.
+// holds reports whether b holds the byte x.
 func (b *byteSet) get(x uint8) bool {
-	return b[x>>6]&(1<<(x&63)) != 0
+	return b[x]
 }
 
 // set ensures that x is in the set.
 func (b *byteSet) set(x uint8) {
-	b[x>>6] |= 1 << (x & 63)
+	b[x] = true
 }
 
 // union returns the union of b and b1.
 func (b *byteSet) union(b1 *byteSet) *byteSet {
 	r := *b
 	for i := range r {
-		r[i] |= b1[i]
+		r[i] = r[i] || b1[i]
 	}
 	return &r
 }
@@ -37,7 +35,7 @@ func (b *byteSet) union(b1 *byteSet) *byteSet {
 func (b *byteSet) invert() *byteSet {
 	r := *b
 	for i := range r {
-		r[i] = ^r[i]
+		r[i] = !r[i]
 	}
 	return &r
 }

--- a/influxdata/tokenizer_test.go
+++ b/influxdata/tokenizer_test.go
@@ -294,22 +294,36 @@ func TestTokenizer(t *testing.T) {
 		c.Run(test.testName, func(c *qt.C) {
 			// Remove section and entry separators, as we're testing all sections.
 			tok := NewTokenizerWithBytes([]byte(removeTestSeparators(test.text)))
-			i := 0
-			for tok.Next() {
-				if i >= len(test.expect) {
-					c.Errorf("too many points found")
-				}
-				for sect, checkSection := range sectionCheckers {
-					c.Logf("checking %v", Section(sect))
-					if i < len(test.expect) {
-						checkSection(c, tok, test.expect[i])
-					}
-				}
-				i++
-			}
-			c.Assert(i, qt.Equals, len(test.expect))
+			assertTokenizeResult(c, tok, test.expect, false)
 		})
 	}
+}
+
+// assertTokenizeResult asserts that the tokens from tok match
+// the expected points and returns the number of points
+// consumed. If allowMore is true, it's OK for there
+// to be more points than expected.
+func assertTokenizeResult(c *qt.C, tok *Tokenizer, expect []Point, allowMore bool) int {
+	i := 0
+	for {
+		if i >= len(expect) && allowMore {
+			return i
+		}
+		if !tok.Next() {
+			break
+		}
+		if i >= len(expect) {
+			c.Errorf("too many points found")
+		}
+		for _, checkSection := range sectionCheckers {
+			if i < len(expect) {
+				checkSection(c, tok, expect[i])
+			}
+		}
+		i++
+	}
+	c.Assert(i, qt.Equals, len(expect))
+	return i
 }
 
 func TestTokenizerAtSection(t *testing.T) {
@@ -662,6 +676,456 @@ func (r *errorReader) Read(buf []byte) (int, error) {
 		err = r.err
 	}
 	return n, err
+}
+
+var scanEntriesBenchmarks = []struct {
+	name     string
+	makeData func() (data []byte, totalEntries int)
+	expect   Point
+}{{
+	name: "long-lines",
+	makeData: func() (data []byte, totalEntries int) {
+		entry := `name,tag1=baz,tag2=asdfvdfsvdsvdfs,tagvdsvd=hello field="` + strings.Repeat("a", 4500) + `" 1602841605822791506`
+		var buf bytes.Buffer
+		for buf.Len() < 25*1024*1024 {
+			buf.WriteString(entry)
+			buf.WriteByte('\n')
+			totalEntries++
+		}
+		return buf.Bytes(), totalEntries
+	},
+	expect: Point{
+		Measurement: "name",
+		Tags: []TagKeyValue{{
+			Key:   "tag1",
+			Value: "baz",
+		}, {
+			Key:   "tag2",
+			Value: "asdfvdfsvdsvdfs",
+		}, {
+			Key:   "tagvdsvd",
+			Value: "hello",
+		}},
+		Fields: []FieldKeyValue{{
+			Key:   "field",
+			Kind:  String,
+			Value: strings.Repeat("a", 4500),
+		}},
+		Time: "1602841605822791506",
+	},
+}, {
+	name: "long-lines-with-escapes",
+	makeData: func() (data []byte, totalEntries int) {
+		entry := `name,ta\=g1=foo\ bar\,baz,tag2=asdfvdfsvdsvdfs,tag\=vdsvd=hello field="` + strings.Repeat(`\"`, 4500) + `" 1602841605822791506`
+		var buf bytes.Buffer
+		for buf.Len() < 25*1024*1024 {
+			buf.WriteString(entry)
+			buf.WriteByte('\n')
+			totalEntries++
+		}
+		return buf.Bytes(), totalEntries
+	},
+	expect: Point{
+		Measurement: "name",
+		Tags: []TagKeyValue{{
+			Key:   "ta=g1",
+			Value: "foo bar,baz",
+		}, {
+			Key:   "tag2",
+			Value: "asdfvdfsvdsvdfs",
+		}, {
+			Key:   "tag=vdsvd",
+			Value: "hello",
+		}},
+		Fields: []FieldKeyValue{{
+			Key:   "field",
+			Kind:  String,
+			Value: strings.Repeat(`"`, 4500),
+		}},
+		Time: "1602841605822791506",
+	},
+}, {
+	name: "single-short-line",
+	makeData: func() ([]byte, int) {
+		return []byte(`x,t=y y=1 1602841605822791506`), 1
+	},
+	expect: Point{
+		Measurement: "x",
+		Tags: []TagKeyValue{{
+			Key:   "t",
+			Value: "y",
+		}},
+		Fields: []FieldKeyValue{{
+			Key:   "y",
+			Kind:  Float,
+			Value: "1",
+		}},
+		Time: "1602841605822791506",
+	},
+}, {
+	name:     "single-short-line-with-escapes",
+	makeData: singleEntry(`x,t=y\,y y=1 1602841605822791506`),
+	expect: Point{
+		Measurement: "x",
+		Tags: []TagKeyValue{{
+			Key:   "t",
+			Value: "y,y",
+		}},
+		Fields: []FieldKeyValue{{
+			Key:   "y",
+			Kind:  Float,
+			Value: "1",
+		}},
+		Time: "1602841605822791506",
+	},
+}, {
+	name: "many-short-lines",
+	makeData: func() (data []byte, totalEntries int) {
+		entry := `x,t=y y=1 1602841605822791506`
+		var buf bytes.Buffer
+		for buf.Len() < 25*1024*1024 {
+			buf.WriteString(entry)
+			buf.WriteByte('\n')
+			totalEntries++
+		}
+		return buf.Bytes(), totalEntries
+	},
+	expect: Point{
+		Measurement: "x",
+		Tags: []TagKeyValue{{
+			Key:   "t",
+			Value: "y",
+		}},
+		Fields: []FieldKeyValue{{
+			Key:   "y",
+			Kind:  Float,
+			Value: "1",
+		}},
+		Time: "1602841605822791506",
+	},
+}, {
+	name:     "field-key-escape-not-escapable",
+	makeData: singleEntry(`cpu va\lue=42 1602841605822791506`),
+	expect: Point{
+		Measurement: "cpu",
+		Fields: []FieldKeyValue{{
+			Key:   `va\lue`,
+			Kind:  Float,
+			Value: "42",
+		}},
+		Time: "1602841605822791506",
+	},
+}, {
+	name:     "tag-value-triple-escape-space",
+	makeData: singleEntry(`cpu,host=two\\\ words value=42 1602841605822791506`),
+	expect: Point{
+		Measurement: "cpu",
+		Tags: []TagKeyValue{{
+			Key:   "host",
+			Value: `two\\ words`,
+		}},
+		Fields: []FieldKeyValue{{
+			Key:   `value`,
+			Kind:  Float,
+			Value: "42",
+		}},
+		Time: "1602841605822791506",
+	},
+}, {
+	name:     "procstat",
+	makeData: singleEntry(`procstat,exe=bash,process_name=bash voluntary_context_switches=42i,memory_rss=5103616i,rlimit_memory_data_hard=2147483647i,cpu_time_user=0.02,rlimit_file_locks_soft=2147483647i,pid=29417i,cpu_time_nice=0,rlimit_memory_locked_soft=65536i,read_count=259i,rlimit_memory_vms_hard=2147483647i,memory_swap=0i,rlimit_num_fds_soft=1024i,rlimit_nice_priority_hard=0i,cpu_time_soft_irq=0,cpu_time=0i,rlimit_memory_locked_hard=65536i,realtime_priority=0i,signals_pending=0i,nice_priority=20i,cpu_time_idle=0,memory_stack=139264i,memory_locked=0i,rlimit_memory_stack_soft=8388608i,cpu_time_iowait=0,cpu_time_guest=0,cpu_time_guest_nice=0,rlimit_memory_data_soft=2147483647i,read_bytes=0i,rlimit_cpu_time_soft=2147483647i,involuntary_context_switches=2i,write_bytes=106496i,cpu_time_system=0,cpu_time_irq=0,cpu_usage=0,memory_vms=21659648i,memory_data=1576960i,rlimit_memory_stack_hard=2147483647i,num_threads=1i,rlimit_memory_rss_soft=2147483647i,rlimit_realtime_priority_soft=0i,num_fds=4i,write_count=35i,rlimit_signals_pending_soft=78994i,cpu_time_steal=0,rlimit_num_fds_hard=4096i,rlimit_file_locks_hard=2147483647i,rlimit_cpu_time_hard=2147483647i,rlimit_signals_pending_hard=78994i,rlimit_nice_priority_soft=0i,rlimit_memory_rss_hard=2147483647i,rlimit_memory_vms_soft=2147483647i,rlimit_realtime_priority_hard=0i 1517620624000000000`),
+	expect: Point{
+		Measurement: "procstat",
+		Tags: []TagKeyValue{{
+			Key:   "exe",
+			Value: "bash",
+		}, {
+			Key:   "process_name",
+			Value: "bash",
+		}},
+		Fields: []FieldKeyValue{{
+			Key:   "voluntary_context_switches",
+			Kind:  Int,
+			Value: "42",
+		}, {
+			Key:   "memory_rss",
+			Kind:  Int,
+			Value: "5103616",
+		}, {
+			Key:   "rlimit_memory_data_hard",
+			Kind:  Int,
+			Value: "2147483647",
+		}, {
+			Key:   "cpu_time_user",
+			Kind:  Float,
+			Value: "0.02",
+		}, {
+			Key:   "rlimit_file_locks_soft",
+			Kind:  Int,
+			Value: "2147483647",
+		}, {
+			Key:   "pid",
+			Kind:  Int,
+			Value: "29417",
+		}, {
+			Key:   "cpu_time_nice",
+			Kind:  Float,
+			Value: "0",
+		}, {
+			Key:   "rlimit_memory_locked_soft",
+			Kind:  Int,
+			Value: "65536",
+		}, {
+			Key:   "read_count",
+			Kind:  Int,
+			Value: "259",
+		}, {
+			Key:   "rlimit_memory_vms_hard",
+			Kind:  Int,
+			Value: "2147483647",
+		}, {
+			Key:   "memory_swap",
+			Kind:  Int,
+			Value: "0",
+		}, {
+			Key:   "rlimit_num_fds_soft",
+			Kind:  Int,
+			Value: "1024",
+		}, {
+			Key:   "rlimit_nice_priority_hard",
+			Kind:  Int,
+			Value: "0",
+		}, {
+			Key:   "cpu_time_soft_irq",
+			Kind:  Float,
+			Value: "0",
+		}, {
+			Key:   "cpu_time",
+			Kind:  Int,
+			Value: "0",
+		}, {
+			Key:   "rlimit_memory_locked_hard",
+			Kind:  Int,
+			Value: "65536",
+		}, {
+			Key:   "realtime_priority",
+			Kind:  Int,
+			Value: "0",
+		}, {
+			Key:   "signals_pending",
+			Kind:  Int,
+			Value: "0",
+		}, {
+			Key:   "nice_priority",
+			Kind:  Int,
+			Value: "20",
+		}, {
+			Key:   "cpu_time_idle",
+			Kind:  Float,
+			Value: "0",
+		}, {
+			Key:   "memory_stack",
+			Kind:  Int,
+			Value: "139264",
+		}, {
+			Key:   "memory_locked",
+			Kind:  Int,
+			Value: "0",
+		}, {
+			Key:   "rlimit_memory_stack_soft",
+			Kind:  Int,
+			Value: "8388608",
+		}, {
+			Key:   "cpu_time_iowait",
+			Kind:  Float,
+			Value: "0",
+		}, {
+			Key:   "cpu_time_guest",
+			Kind:  Float,
+			Value: "0",
+		}, {
+			Key:   "cpu_time_guest_nice",
+			Kind:  Float,
+			Value: "0",
+		}, {
+			Key:   "rlimit_memory_data_soft",
+			Kind:  Int,
+			Value: "2147483647",
+		}, {
+			Key:   "read_bytes",
+			Kind:  Int,
+			Value: "0",
+		}, {
+			Key:   "rlimit_cpu_time_soft",
+			Kind:  Int,
+			Value: "2147483647",
+		}, {
+			Key:   "involuntary_context_switches",
+			Kind:  Int,
+			Value: "2",
+		}, {
+			Key:   "write_bytes",
+			Kind:  Int,
+			Value: "106496",
+		}, {
+			Key:   "cpu_time_system",
+			Kind:  Float,
+			Value: "0",
+		}, {
+			Key:   "cpu_time_irq",
+			Kind:  Float,
+			Value: "0",
+		}, {
+			Key:   "cpu_usage",
+			Kind:  Float,
+			Value: "0",
+		}, {
+			Key:   "memory_vms",
+			Kind:  Int,
+			Value: "21659648",
+		}, {
+			Key:   "memory_data",
+			Kind:  Int,
+			Value: "1576960",
+		}, {
+			Key:   "rlimit_memory_stack_hard",
+			Kind:  Int,
+			Value: "2147483647",
+		}, {
+			Key:   "num_threads",
+			Kind:  Int,
+			Value: "1",
+		}, {
+			Key:   "rlimit_memory_rss_soft",
+			Kind:  Int,
+			Value: "2147483647",
+		}, {
+			Key:   "rlimit_realtime_priority_soft",
+			Kind:  Int,
+			Value: "0",
+		}, {
+			Key:   "num_fds",
+			Kind:  Int,
+			Value: "4",
+		}, {
+			Key:   "write_count",
+			Kind:  Int,
+			Value: "35",
+		}, {
+			Key:   "rlimit_signals_pending_soft",
+			Kind:  Int,
+			Value: "78994",
+		}, {
+			Key:   "cpu_time_steal",
+			Kind:  Float,
+			Value: "0",
+		}, {
+			Key:   "rlimit_num_fds_hard",
+			Kind:  Int,
+			Value: "4096",
+		}, {
+			Key:   "rlimit_file_locks_hard",
+			Kind:  Int,
+			Value: "2147483647",
+		}, {
+			Key:   "rlimit_cpu_time_hard",
+			Kind:  Int,
+			Value: "2147483647",
+		}, {
+			Key:   "rlimit_signals_pending_hard",
+			Kind:  Int,
+			Value: "78994",
+		}, {
+			Key:   "rlimit_nice_priority_soft",
+			Kind:  Int,
+			Value: "0",
+		}, {
+			Key:   "rlimit_memory_rss_hard",
+			Kind:  Int,
+			Value: "2147483647",
+		}, {
+			Key:   "rlimit_memory_vms_soft",
+			Kind:  Int,
+			Value: "2147483647",
+		}, {
+			Key:   "rlimit_realtime_priority_hard",
+			Kind:  Int,
+			Value: "0",
+		}},
+		Time: "1517620624000000000",
+	},
+}}
+
+func singleEntry(s string) func() ([]byte, int) {
+	return func() ([]byte, int) {
+		return []byte(s), 1
+	}
+}
+
+func BenchmarkScanEntriesSkipping(b *testing.B) {
+	for _, bench := range scanEntriesBenchmarks {
+		b.Run(bench.name, func(b *testing.B) {
+			data, total := bench.makeData()
+			c := qt.New(b)
+			// Sanity check that the tokenizer is doing what we're expecting.
+			// Only check the first entry because checking them all is slow.
+			tok := NewTokenizerWithBytes(data)
+			assertTokenizeResult(c, tok, []Point{bench.expect}, true)
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				n := 0
+				tok := NewTokenizerWithBytes(data)
+				for tok.Next() {
+					n++
+				}
+				if n != total {
+					b.Fatalf("unexpected read count; got %v want %v", n, total)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkScanEntriesWithoutSkipping(b *testing.B) {
+	for _, bench := range scanEntriesBenchmarks {
+		b.Run(bench.name, func(b *testing.B) {
+			data, total := bench.makeData()
+			c := qt.New(b)
+			// Sanity check that the tokenizer is doing what we're expecting.
+			// Only check the first entry because checking them all is slow.
+			tok := NewTokenizerWithBytes(data)
+			assertTokenizeResult(c, tok, []Point{bench.expect}, true)
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.SetBytes(int64(len(data)))
+			for i := 0; i < b.N; i++ {
+				n := 0
+				tok := NewTokenizerWithBytes(data)
+				for tok.Next() {
+					tok.Measurement()
+					for {
+						key, _, _ := tok.NextTag()
+						if key == nil {
+							break
+						}
+					}
+					for {
+						key, _, _ := tok.NextField()
+						if key == nil {
+							break
+						}
+					}
+					tok.TimeBytes()
+					n++
+				}
+				if n != total {
+					b.Fatalf("unexpected read count; got %v want %v", n, total)
+				}
+			}
+		})
+	}
 }
 
 func BenchmarkTokenize(b *testing.B) {


### PR DESCRIPTION
Also change the representation of byte sets to `[256]bool` which
speeds things up by quite a bit.

Here's the benchmark comparison between the version that uses
`[4]uint64` and the version proposed in this PR.

```
name                                                         old time/op    new time/op     delta
ScanEntriesSkipping/long-lines-8                               36.2ms ± 5%     16.7ms ± 2%   -53.81%  (p=0.008 n=5+5)
ScanEntriesSkipping/long-lines-with-escapes-8                  21.7ms ± 1%     17.8ms ± 1%   -18.20%  (p=0.008 n=5+5)
ScanEntriesSkipping/single-short-line-8                         288ns ± 6%      237ns ±12%   -17.71%  (p=0.008 n=5+5)
ScanEntriesSkipping/single-short-line-with-escapes-8            303ns ± 3%      228ns ± 4%   -24.77%  (p=0.008 n=5+5)
ScanEntriesSkipping/many-short-lines-8                          143ms ± 3%      130ms ±18%      ~     (p=0.151 n=5+5)
ScanEntriesSkipping/field-key-escape-not-escapable-8            271ns ± 2%      278ns ±14%      ~     (p=0.508 n=5+5)
ScanEntriesSkipping/tag-value-triple-escape-space-8             375ns ±14%      278ns ± 6%   -25.80%  (p=0.008 n=5+5)
ScanEntriesSkipping/procstat-8                                 3.83µs ± 2%     2.26µs ± 1%   -41.05%  (p=0.008 n=5+5)
ScanEntriesWithoutSkipping/long-lines-8                        42.9ms ± 1%     18.4ms ± 1%   -57.01%  (p=0.008 n=5+5)
ScanEntriesWithoutSkipping/long-lines-with-escapes-8            116ms ± 5%       93ms ± 1%   -19.38%  (p=0.008 n=5+5)
ScanEntriesWithoutSkipping/single-short-line-8                  392ns ± 2%      304ns ± 3%   -22.45%  (p=0.008 n=5+5)
ScanEntriesWithoutSkipping/single-short-line-with-escapes-8     462ns ±26%      323ns ± 1%   -30.07%  (p=0.008 n=5+5)
ScanEntriesWithoutSkipping/many-short-lines-8                   243ms ±16%      153ms ± 1%   -37.02%  (p=0.008 n=5+5)
ScanEntriesWithoutSkipping/field-key-escape-not-escapable-8     400ns ± 8%      282ns ± 3%   -29.50%  (p=0.008 n=5+5)
ScanEntriesWithoutSkipping/tag-value-triple-escape-space-8      478ns ± 7%      379ns ±10%   -20.79%  (p=0.008 n=5+5)
ScanEntriesWithoutSkipping/procstat-8                          7.02µs ± 7%     5.23µs ± 2%   -25.51%  (p=0.008 n=5+5)
Tokenize-8                                                     43.4ms ±10%     20.1ms ± 3%   -53.83%  (p=0.008 n=5+5)

name                                                         old speed      new speed       delta
ScanEntriesSkipping/long-lines-8                              725MB/s ± 5%   1568MB/s ± 2%  +116.25%  (p=0.008 n=5+5)
ScanEntriesSkipping/long-lines-with-escapes-8                1.21GB/s ± 1%   1.48GB/s ± 1%   +22.24%  (p=0.008 n=5+5)
ScanEntriesSkipping/single-short-line-8                       101MB/s ± 6%    123MB/s ±11%   +22.11%  (p=0.008 n=5+5)
ScanEntriesSkipping/single-short-line-with-escapes-8          106MB/s ± 3%    141MB/s ± 4%   +32.99%  (p=0.008 n=5+5)
ScanEntriesSkipping/many-short-lines-8                        183MB/s ± 3%    203MB/s ±16%      ~     (p=0.151 n=5+5)
ScanEntriesSkipping/field-key-escape-not-escapable-8          122MB/s ± 2%    120MB/s ±15%      ~     (p=0.548 n=5+5)
ScanEntriesSkipping/tag-value-triple-escape-space-8           134MB/s ±16%    180MB/s ± 6%   +33.84%  (p=0.008 n=5+5)
ScanEntriesSkipping/procstat-8                                347MB/s ± 2%    588MB/s ± 1%   +69.62%  (p=0.008 n=5+5)
ScanEntriesWithoutSkipping/long-lines-8                       612MB/s ± 1%   1423MB/s ± 1%  +132.61%  (p=0.008 n=5+5)
ScanEntriesWithoutSkipping/long-lines-with-escapes-8          227MB/s ± 5%    281MB/s ± 1%   +23.96%  (p=0.008 n=5+5)
ScanEntriesWithoutSkipping/single-short-line-8               74.0MB/s ± 2%   95.4MB/s ± 3%   +28.93%  (p=0.008 n=5+5)
ScanEntriesWithoutSkipping/single-short-line-with-escapes-8  70.4MB/s ±22%   99.2MB/s ± 1%   +40.92%  (p=0.008 n=5+5)
ScanEntriesWithoutSkipping/many-short-lines-8                 109MB/s ±15%    171MB/s ± 1%   +56.85%  (p=0.008 n=5+5)
ScanEntriesWithoutSkipping/field-key-escape-not-escapable-8  82.7MB/s ± 9%  117.1MB/s ± 3%   +41.56%  (p=0.008 n=5+5)
ScanEntriesWithoutSkipping/tag-value-triple-escape-space-8    105MB/s ± 7%    133MB/s ±11%   +26.67%  (p=0.008 n=5+5)
ScanEntriesWithoutSkipping/procstat-8                         189MB/s ± 8%    254MB/s ± 2%   +33.93%  (p=0.008 n=5+5)
Tokenize-8                                                    606MB/s ±10%   1308MB/s ± 3%  +115.90%  (p=0.008 n=5+5)
```