### PR TITLE
influxdata: update syntax

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/influxdata/line-protocol
+module github.com/influxdata/line-protocol/v2
 
 go 1.15
 

--- a/influxdata/byteset.go
+++ b/influxdata/byteset.go
@@ -10,6 +10,15 @@ func newByteSet(s string) *byteSet {
 	return &set
 }
 
+func newByteSetRange(i0, i1 uint8) *byteSet {
+	var set byteSet
+	for i := i0; i <= i1; i++ {
+		set.set(i)
+
+	}
+	return &set
+}
+
 type byteSet [256]bool
 
 // holds reports whether b holds the byte x.
@@ -29,6 +38,19 @@ func (b *byteSet) union(b1 *byteSet) *byteSet {
 		r[i] = r[i] || b1[i]
 	}
 	return &r
+}
+
+// union returns the union of b and b1.
+func (b *byteSet) intersect(b1 *byteSet) *byteSet {
+	r := *b
+	for i := range r {
+		r[i] = r[i] && b1[i]
+	}
+	return &r
+}
+
+func (b *byteSet) without(b1 *byteSet) *byteSet {
+	return b.intersect(b1.invert())
 }
 
 // invert returns everything not in b.

--- a/influxdata/corpus_test.go
+++ b/influxdata/corpus_test.go
@@ -21,6 +21,26 @@ import (
 // all the current implementations are wrong.
 var corpusAllowList = map[string]string{
 	"4e8bcb126274d3290789538902dab6ee": "no trailing backslash",
+	"13a9b07a16a3adfe3480654a86d02e38": "non-printable character in measurement or key",
+	"25957c0a9f5e3a8c28124d338e73bad3": "non-printable character in measurement or key",
+	"2cad3ab7d1f6c69175256bd38427e41b": "non-printable character in measurement or key",
+	"2df1f638db625653021bdd81d082aa7b": "non-printable character in measurement or key",
+	"34e61d66cbcbb9396d649d96abb9cfc8": "non-printable character in measurement or key",
+	"43020303d156ae3e021b05606aac1e4e": "non-printable character in measurement or key",
+	"51909957b5a97015a9fde47953331e91": "non-printable character in measurement or key",
+	"7e0ed32d7d67962c4aca9cdb4a33810b": "non-printable character in measurement or key",
+	"9017c9c3ef7ab576ecca88c4e7c4f93d": "non-printable character in measurement or key",
+	"97d1c1087409d74398d4c1a2ba0db15c": "non-printable character in measurement or key",
+	"9f2ffee457c600e2bb7dc02863e206ab": "non-printable character in measurement or key",
+	"a2104143356bbe4f000c8d513d8f73e8": "non-printable character in measurement or key",
+	"a5ad697c142e6043f0891a33b762ec73": "non-printable character in measurement or key",
+	"a667a7c1a0587907bf12d6c3cc130fa8": "non-printable character in measurement or key",
+	"b08459b50de67f9c766806fac2039f5e": "non-printable character in measurement or key",
+	"b5c0ed5b3beaaff0210c645b3e8f42b1": "non-printable character in measurement or key",
+	"ca0fab37d66bfe0a70b01297141f179c": "non-printable character in measurement or key",
+	"f8ccd78f52d6485b24303a99b4c314b2": "non-printable character in measurement or key",
+	"f9d6e94df94cb7ae71cc5468ede46fcd": "non-printable character in measurement or key",
+	"fd0df398c06cca4efbb3fcb7061acbb7": "non-printable character in measurement or key",
 }
 
 func TestCorpus(t *testing.T) {
@@ -95,7 +115,7 @@ func tokenizeToCorpusMetrics(text []byte, precision string, defaultTime int64) (
 	for tok.Next() {
 		m, err := tokenizeToCorpusMetric(tok, precision, defaultTime)
 		if err != nil {
-			return nil, fmt.Errorf("cannot get metric %v: %v", len(ms), err)
+			return nil, fmt.Errorf("cannot get metric for point %d: %v", len(ms), err)
 		}
 		ms = append(ms, m)
 	}

--- a/influxdata/value_test.go
+++ b/influxdata/value_test.go
@@ -54,17 +54,17 @@ var parseValueTests = []struct {
 	testName:    "invalid-int",
 	kind:        Int,
 	data:        "1e3",
-	expectError: `invalid integer value "1e3"`,
+	expectError: `invalid integer value syntax`,
 }, {
 	testName:    "invalid-uint",
 	kind:        Uint,
 	data:        "1e3",
-	expectError: `invalid unsigned integer value "1e3"`,
+	expectError: `invalid unsigned integer value syntax`,
 }, {
 	testName:    "invalid-float",
 	kind:        Float,
 	data:        "1e3a",
-	expectError: `invalid float value "1e3a"`,
+	expectError: `invalid float value syntax`,
 }, {
 	testName:    "NaN",
 	kind:        Float,
@@ -90,6 +90,21 @@ var parseValueTests = []struct {
 	kind:        125,
 	data:        "nope",
 	expectError: `unexpected value kind 125 \(value "nope"\)`,
+}, {
+	testName:    "out-of-range-int",
+	kind:        Int,
+	data:        "18446744073709552000",
+	expectError: `line-protocol value out of range`,
+}, {
+	testName:    "out-of-range-uint",
+	kind:        Uint,
+	data:        "18446744073709552000",
+	expectError: `line-protocol value out of range`,
+}, {
+	testName:    "out-of-range-float",
+	kind:        Float,
+	data:        "1e18446744073709552000",
+	expectError: `line-protocol value out of range`,
 }}
 
 func TestValueCreation(t *testing.T) {

--- a/line-protocol.ebnf
+++ b/line-protocol.ebnf
@@ -1,0 +1,49 @@
+// This file holds a grammar for the line-protocol syntax.
+// The grammar is in EBNF format as used in the Go specification.
+
+lines = line { [ "\r" ] "\n" line } [ "\r" ] .
+
+space_char = " " .
+whitespace = space_char { space_char } .
+nonprintable_char = "\u0000"…"\u001f" | "\u007f" .
+
+line = { space_char } [ point | comment ] .
+point = measurement { "," tag } whitespace field { "," field } [ whitespace timestamp ] { space_char } .
+comment = "#" { not(nonprintable_char) | "\t" } .
+
+measurement = measurement_start { measurement_elem } .
+// Note: the start character is different from other measurement characters
+// because it can't be a # character (otherwise it would match a comment).
+measurement_start = not(nonprintable_char | space_char | `\` | "," | "#" )  | measurement_escape_seq .
+measurement_elem = measurement_regular_char | measurement_escape_seq .
+measurement_regular_char = not(nonprintable_char | space_char | `\` | "," ) .
+measurement_escape_seq = `\` {  `\` } not ( `\` | nonprintable_char ).
+
+key = key_elem { key_elem } .
+key_elem = key_regular_char | key_escape_seq .
+key_regular_char = not(nonprintable_char | space_char | `\` | "," | "=" ) .
+key_escape_seq = `\` {  `\` } not ( `\`  | nonprintable_char ) .
+
+tag = key "=" key .
+
+field = key "=" fieldval .
+
+fieldval = boolfield | stringfield | intfield | uintfield | floatfield .
+decimal_digits = decimal_digit { decimal_digit } .
+decimal_digit = "0" … "9" .
+
+boolfield = "t" | "T" | "true" | "True" | "TRUE" | "f" | "F" | "false" | "False" | "FALSE" .
+intfield = [ "-" ] decimal_digits "i" .
+uintfield = decimal_digits "u" .
+
+floatfield = [ "-" ] non_negative_float .
+non_negative_float = decimal_digits [ "." [ decimal_digits ] [ decimal_exponent ] ] |
+                    decimal_digits decimal_exponent |
+                    "." decimal_digits [ decimal_exponent ] .
+
+decimal_exponent  = ( "e" | "E" ) [ "+" | "-" ] decimal_digits .
+
+stringfield = `"` { not(`"` | `\`) | `\` any_char } `"` .
+any_char = "\u0000" … "\U0010FFFF" .
+
+timestamp = [ "-" ] decimal_digits .


### PR DESCRIPTION
This change updates the syntax to use most of the newly proposed syntax,
including allowing CR only before NL and disallowing
non-printable ASCII except in string field values.

The main thing not done yet is utf-8 validity checking, which will be
done in its own PR.