### PR TITLE
influxdata: implement Encoder

### DIFF
--- a/influxdata/encoder.go
+++ b/influxdata/encoder.go
@@ -1,0 +1,288 @@
+package influxdata
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+	"unicode/utf8"
+)
+
+// Encoder encapsulates the encoding part of the line protocol.
+//
+// The zero value of an Encoder is ready to use.
+//
+// It is associated with a []byte buffer which is appended to
+// each time a method is called.
+//
+// When an error is encountered encoding a point,
+// the Err method returns it, and the erroneous point
+// is omitted from the result.
+//
+type Encoder struct {
+	buf        []byte
+	prevTagKey []byte
+	// lineStart holds the index of the start of the current line.
+	lineStart int
+	// section holds the section of line that's about to be added.
+	section Section
+	// lax holds whether keys and values are checked for validity
+	// when being encoded.
+	lax bool
+	// lineHasError records whether there's been an error encountered
+	// on the current entry, in which case, no further data will be added
+	// until the next entry.
+	lineHasError bool
+	// err holds the most recent error encountered when encoding.
+	err error
+	// precisionMultiplier holds the timestamp precision.
+	// Timestamps are divided by this when encoded.
+	precisionMultiplier int64
+}
+
+// Bytes returns the current line buffer.
+func (e *Encoder) Bytes() []byte {
+	return e.buf
+}
+
+// SetBuffer sets the buffer used for the line,
+// clears any current error and resets the line.
+//
+// Encoded data will be appended to buf.
+func (e *Encoder) SetBuffer(buf []byte) {
+	e.buf = buf
+	e.ClearErr()
+	e.section = MeasurementSection
+}
+
+// SetPrecision sets the precision used to encode the time stamps
+// in the encoded messages. The default precision is Nanosecond.
+// Timestamps are truncated to this precision.
+func (e *Encoder) SetPrecision(p Precision) {
+	e.precisionMultiplier = int64(p.Duration())
+}
+
+// Reset resets the line, clears any error, and starts writing at the start
+// of the line buffer slice.
+func (e *Encoder) Reset() {
+	e.SetBuffer(e.buf[:0])
+}
+
+// SetLax sets whether the Encoder methods check fully for validity or not.
+// When Lax is true:
+//
+// - measurement names, tag and field keys aren't checked for invalid characters
+// - field values passed to AddRawField are not bounds or syntax checked
+// - tag keys are not checked to be in alphabetical order.
+//
+// This can be used to increase performance in
+// places where values are already known to be valid.
+func (e *Encoder) SetLax(lax bool) {
+	e.lax = lax
+}
+
+// Err returns the first encoding error that's been encountered so far,
+// if any.
+// TODO define a type so that we can get access to the line where it happened.
+func (e *Encoder) Err() error {
+	return e.err
+}
+
+// ClearErr clears any current encoding error.
+func (e *Encoder) ClearErr() {
+	e.err = nil
+}
+
+// StartLine starts writing a line with the given measurement name. If this
+// is called when it's not possible to start a new entry, or the
+// measurement cannot be encoded, it will return an error.
+//
+// Starting a new entry is always allowed when there's been an error
+// encoding the previous entry.
+func (e *Encoder) StartLine(measurement string) {
+	section := e.section
+	e.section = TagSection
+	if section == TagSection {
+		// This error is unusual, because it indicates an error on the previous
+		// line, even though there's probably not an error on this line, so
+		// don't return here. This means that unfortunately, if you
+		// add a line with an invalid measurement immediately after
+		// adding a line with no fields, you won't ever see the second
+		// of those two errors. Clients can avoid that possibility by making
+		// sure to call EndLine even if they don't wish to add a timestamp.
+		e.setError(fmt.Errorf("cannot start line without adding at least one field to previous line"))
+	}
+	e.prevTagKey = e.prevTagKey[:0]
+	e.lineStart = len(e.buf)
+	e.lineHasError = false
+	if !e.lax {
+		if !validMeasurementOrKey(measurement) {
+			e.setError(fmt.Errorf("invalid measurement %q", measurement))
+			return
+		}
+	}
+	if section != MeasurementSection {
+		// This isn't the first line, so add a newline separator.
+		e.buf = append(e.buf, '\n')
+	}
+	e.buf = measurementEscapes.appendEscaped(e.buf, measurement)
+}
+
+// StartLineRaw is the same as Start except that it accepts a byte slice
+// instead of a string, which can save allocations.
+func (e *Encoder) StartLineRaw(name []byte) {
+	e.StartLine(unsafeBytesToString(name))
+}
+
+// AddTag adds a tag to the line. Tags must be added in lexical order
+// and StartLine must be called after Start and before AddField.
+//
+// Neither the key or the value may contain non-printable ASCII
+// characters (0x00 to 0x1f and 0x7f) or invalid UTF-8 or
+// a trailing backslash character.
+func (e *Encoder) AddTag(key, value string) {
+	if e.section != TagSection {
+		e.setError(fmt.Errorf("tag must be added after adding a measurement and before adding fields"))
+		return
+	}
+	if !e.lax {
+		if !validMeasurementOrKey(key) {
+			e.setError(fmt.Errorf("invalid tag key %q", key))
+			return
+		}
+		if !validMeasurementOrKey(value) {
+			e.setError(fmt.Errorf("invalid tag value %s=%q", key, value))
+			return
+		}
+		if key <= string(e.prevTagKey) {
+			e.setError(fmt.Errorf("tag key %q out of order (previous key %q)", key, e.prevTagKey))
+			return
+		}
+		// We need to copy the tag key because AddTag can be called
+		// by AddTagRaw with a slice of byte which might change from
+		// call to call.
+		e.prevTagKey = append(e.prevTagKey[:0], key...)
+	}
+	if e.lineHasError {
+		return
+	}
+	e.buf = append(e.buf, ',')
+	e.buf = tagKeyEscapes.appendEscaped(e.buf, key)
+	e.buf = append(e.buf, '=')
+	e.buf = tagValEscapes.appendEscaped(e.buf, value)
+}
+
+// AddTagRaw is like AddTag except that it accepts byte slices
+// instead of strings, which can save allocations. Note that
+// AddRawTag _will_ escape metacharacters such as "="
+// and "," when they're present.
+func (e *Encoder) AddTagRaw(key, value []byte) {
+	e.AddTag(unsafeBytesToString(key), unsafeBytesToString(value))
+}
+
+// AddField adds a field to the line. AddField must be called after AddTag
+// or AddMeasurement. At least one field must be added to each line.
+func (e *Encoder) AddField(key string, value Value) {
+	if e.section != FieldSection && e.section != TagSection {
+		e.setError(fmt.Errorf("field must be added after tag or measurement section"))
+		return
+	}
+	section := e.section
+	e.section = FieldSection
+	if !e.lax {
+		if !validMeasurementOrKey(key) {
+			e.setError(fmt.Errorf("invalid field key %q", key))
+			return
+		}
+	}
+	if e.lineHasError {
+		return
+	}
+	if section == TagSection {
+		e.buf = append(e.buf, ' ')
+	} else {
+		e.buf = append(e.buf, ',')
+	}
+	e.buf = fieldKeyEscapes.appendEscaped(e.buf, key)
+	e.buf = append(e.buf, '=')
+	e.buf = value.AppendBytes(e.buf)
+}
+
+// AddFieldRaw is like AddField except that the key is represented
+// as a byte slice instead of a string, which can save allocations.
+// TODO would it be better for this to be:
+//	AddFieldRaw(key []byte, kind ValueKind, data []byte) error
+// so that we could respect lax and be more efficient when reading directly
+// from a Tokenizer?
+func (e *Encoder) AddFieldRaw(key []byte, value Value) {
+	e.AddField(unsafeBytesToString(key), value)
+}
+
+var (
+	minTime = time.Unix(0, math.MinInt64)
+	maxTime = time.Unix(0, math.MaxInt64)
+)
+
+// EndLine adds the timestamp at the end of the line.
+// If t is zero, no timestamp will written and this method will do nothing.
+// If the time is outside the maximum representable time range,
+// an ErrRange error will be returned.
+func (e *Encoder) EndLine(t time.Time) {
+	if e.section != FieldSection {
+		e.setError(fmt.Errorf("timestamp must be added after adding at least one field"))
+		return
+	}
+	e.section = endSection
+	if t.IsZero() {
+		return
+	}
+	if t.Before(minTime) || t.After(maxTime) {
+		e.setError(fmt.Errorf("timestamp %s: %w", t.Format(time.RFC3339), ErrValueOutOfRange))
+		return
+	}
+	if e.lineHasError {
+		return
+	}
+	e.buf = append(e.buf, ' ')
+	timestamp := t.UnixNano()
+	if m := e.precisionMultiplier; m > 0 {
+		timestamp /= m
+	}
+	e.buf = strconv.AppendInt(e.buf, timestamp, 10)
+}
+
+func (e *Encoder) setError(err error) {
+	e.lineHasError = true
+	if e.err == nil {
+		// TODO make a value that includes the current point index.
+		e.err = err
+	}
+	// Remove the partially encoded part of the current line.
+	e.buf = e.buf[:e.lineStart]
+	if len(e.buf) == 0 {
+		// Make sure the next entry doesn't add a newline.
+		e.section = MeasurementSection
+	}
+}
+
+// validMeasurementOrKey reports whether s can be
+// encoded as a valid measurement or key.
+func validMeasurementOrKey(s string) bool {
+	if s == "" {
+		return false
+	}
+	if !utf8.ValidString(s) {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if nonPrintable.get(s[i]) {
+			return false
+		}
+	}
+	//lint:ignore S1008 Leave my comment alone!
+	if s[len(s)-1] == '\\' {
+		// A trailing backslash can't be round-tripped.
+		return false
+	}
+	return true
+}

--- a/influxdata/encoder_test.go
+++ b/influxdata/encoder_test.go
@@ -1,0 +1,444 @@
+package influxdata
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestEncoderWithTokenizerTests(t *testing.T) {
+	c := qt.New(t)
+	runTests := func(c *qt.C, lax bool) {
+		for _, test := range tokenizerTests {
+			if pointsHaveError(test.expect) {
+				// Can't encode a test that results in an error.
+				continue
+			}
+			c.Run(test.testName, func(c *qt.C) {
+				// Always use sorted tags even though they might not
+				// be sorted in the test case.
+				points := append([]Point(nil), test.expect...)
+				for i := range points {
+					points[i] = pointWithSortedTags(points[i])
+				}
+				var e Encoder
+				e.SetLax(lax)
+				for _, p := range points {
+					encodePoint(&e, p)
+				}
+				c.Assert(e.Err(), qt.IsNil)
+				data := e.Bytes()
+				c.Logf("encoded: %q", data)
+				// Check that the data round-trips OK
+				tok := NewTokenizerWithBytes(data)
+				assertTokenizeResult(c, tok, points, false)
+			})
+		}
+	}
+	c.Run("strict", func(c *qt.C) {
+		runTests(c, false)
+	})
+	c.Run("lax", func(c *qt.C) {
+		runTests(c, true)
+	})
+}
+
+func TestEncoderErrorOmitsLine(t *testing.T) {
+	c := qt.New(t)
+	var e Encoder
+	e.StartLine("m1")
+	e.AddField("\xff", MustNewValue(int64(1)))
+	c.Assert(e.Err(), qt.ErrorMatches, `invalid field key "\\xff"`)
+	c.Assert(e.Bytes(), qt.HasLen, 0)
+	e.ClearErr()
+
+	// Check that an error after the first line doesn't erase
+	// everything.
+	e.StartLine("m1")
+	e.AddField("f", MustNewValue(int64(1)))
+	e.StartLine("m2")
+	c.Assert(e.Err(), qt.IsNil)
+	c.Assert(string(e.Bytes()), qt.Equals, "m1 f=1i\nm2")
+	e.AddField("g", MustNewValue(int64(3)))
+	e.AddField("\\", MustNewValue(int64(4)))
+	c.Assert(e.Err(), qt.ErrorMatches, `invalid field key "\\\\"`)
+	c.Assert(string(e.Bytes()), qt.Equals, "m1 f=1i")
+
+	// Check that we can add a new line while retaining the first error.
+	e.StartLine("m3")
+	e.AddField("f", MustNewValue(int64(3)))
+	c.Assert(string(e.Bytes()), qt.Equals, "m1 f=1i\nm3 f=3i")
+	c.Assert(e.Err(), qt.ErrorMatches, `invalid field key "\\\\"`)
+}
+
+func TestEncoderErrorWithOutOfOrderTags(t *testing.T) {
+	c := qt.New(t)
+	var e Encoder
+	e.StartLine("m1")
+	e.AddTag("b", "1")
+	c.Assert(e.Err(), qt.IsNil)
+	e.AddTag("a", "1")
+	c.Assert(e.Err(), qt.ErrorMatches, `tag key "a" out of order \(previous key "b"\)`)
+}
+
+func TestEncoderAddFieldBeforeMeasurement(t *testing.T) {
+	c := qt.New(t)
+	var e Encoder
+	e.AddField("hello", MustNewValue(int64(1)))
+	c.Assert(e.Err(), qt.ErrorMatches, `field must be added after tag or measurement section`)
+}
+
+func TestEncoderEndLineWithNoField(t *testing.T) {
+	c := qt.New(t)
+	var e Encoder
+	e.StartLine("hello")
+	e.EndLine(time.Time{})
+	c.Assert(e.Err(), qt.ErrorMatches, `timestamp must be added after adding at least one field`)
+}
+
+func TestEncoderAddTagBeforeStartLine(t *testing.T) {
+	c := qt.New(t)
+	var e Encoder
+	e.AddTag("a", "b")
+	c.Assert(e.Err(), qt.ErrorMatches, `tag must be added after adding a measurement and before adding fields`)
+}
+
+func TestEncoderAddTagAfterAddField(t *testing.T) {
+	c := qt.New(t)
+	var e Encoder
+	e.StartLine("m")
+	e.AddField("f", MustNewValue(int64(12)))
+	e.AddTag("a", "b")
+	c.Assert(e.Err(), qt.ErrorMatches, `tag must be added after adding a measurement and before adding fields`)
+}
+
+func TestEncoderStartLineWithNoFieldsOnPreviousLine(t *testing.T) {
+	c := qt.New(t)
+	var e Encoder
+	e.StartLine("m")
+	e.StartLine("n")
+	c.Assert(e.Err(), qt.ErrorMatches, `cannot start line without adding at least one field to previous line`)
+}
+
+func TestEncoderStartLineWithInvalidMeasurementAndNoFieldsOnPreviousLine(t *testing.T) {
+	c := qt.New(t)
+	var e Encoder
+	e.StartLine("m")
+	e.StartLine("")
+	c.Assert(e.Err(), qt.ErrorMatches, `cannot start line without adding at least one field to previous line`)
+
+	// The current line is now in error state, so fields won't be added.
+	e.AddField("f", MustNewValue(int64(1)))
+	c.Assert(e.Bytes(), qt.HasLen, 0)
+
+	// The next line gets added OK though.
+	e.StartLine("m")
+	e.AddField("f", MustNewValue(int64(1)))
+	c.Assert(string(e.Bytes()), qt.Equals, "m f=1i")
+}
+
+func TestEncoderWithPrecision(t *testing.T) {
+	c := qt.New(t)
+	var e Encoder
+	e.StartLine("x")
+	e.SetPrecision(Second)
+	e.AddField("f", MustNewValue(int64(1)))
+	e.EndLine(time.Unix(0, 1615196563_299_053_942))
+	c.Assert(string(e.Bytes()), qt.Equals, `x f=1i 1615196563`)
+
+	e.Reset()
+	e.SetPrecision(Microsecond)
+	e.StartLine("x")
+	e.AddField("f", MustNewValue(int64(1)))
+	e.EndLine(time.Unix(0, 1615196563_299_053_942))
+	c.Assert(string(e.Bytes()), qt.Equals, `x f=1i 1615196563299053`)
+}
+
+var encoderDataErrorTests = []struct {
+	testName    string
+	point       Point
+	expectError string
+}{{
+	testName: "EmptyMeasurement",
+	point: Point{
+		Measurement: "",
+		Fields: []FieldKeyValue{{
+			Key:   "f",
+			Value: int64(1),
+		}},
+	},
+	expectError: `invalid measurement ""`,
+}, {
+	testName: "NonPrintableMeasurement",
+	point: Point{
+		Measurement: "\x01",
+		Fields: []FieldKeyValue{{
+			Key:   "f",
+			Value: int64(1),
+		}},
+	},
+	expectError: `invalid measurement "\\x01"`,
+}, {
+	testName: "NonUTF8Measurement",
+	point: Point{
+		Measurement: "\xff",
+		Fields: []FieldKeyValue{{
+			Key:   "f",
+			Value: int64(1),
+		}},
+	},
+	expectError: `invalid measurement "\\xff"`,
+}, {
+	testName: "MeasurementWithTrailingBackslash",
+	point: Point{
+		Measurement: "x\\",
+		Fields: []FieldKeyValue{{
+			Key:   "f",
+			Value: int64(1),
+		}},
+	},
+	expectError: `invalid measurement "x\\\\"`,
+}, {
+	testName: "InvalidTagKey",
+	point: Point{
+		Measurement: "m",
+		Tags: []TagKeyValue{{
+			Key:   "",
+			Value: "x",
+		}, {
+			Key:   "b",
+			Value: "x",
+		}},
+		Fields: []FieldKeyValue{{
+			Key:   "f",
+			Value: int64(1),
+		}},
+	},
+	expectError: `invalid tag key ""`,
+}, {
+	testName: "InvalidTagValue",
+	point: Point{
+		Measurement: "m",
+		Tags: []TagKeyValue{{
+			Key:   "x",
+			Value: "",
+		}},
+		Fields: []FieldKeyValue{{
+			Key:   "f",
+			Value: int64(1),
+		}},
+	},
+	expectError: `invalid tag value x=""`,
+}, {
+	testName: "OutOfOrderTag",
+	point: Point{
+		Measurement: "m",
+		Tags: []TagKeyValue{{
+			Key:   "x",
+			Value: "1",
+		}, {
+			Key:   "a",
+			Value: "1",
+		}},
+		Fields: []FieldKeyValue{{
+			Key:   "f",
+			Value: int64(1),
+		}},
+	},
+	expectError: `tag key "a" out of order \(previous key "x"\)`,
+}, {
+	testName: "InvalidFieldKey",
+	point: Point{
+		Measurement: "m",
+		Fields: []FieldKeyValue{{
+			Key:   "",
+			Value: int64(1),
+		}},
+		// Include an explicit timestamp so that we test the path
+		// in Endline that checks lineHasError.
+		Time: "123456",
+	},
+	expectError: `invalid field key ""`,
+}, {
+	testName: "TimeStampTooEarly",
+	point: Point{
+		Measurement: "m",
+		Fields: []FieldKeyValue{{
+			Key:   "x",
+			Value: int64(1),
+		}},
+		Time: "1000-01-01T12:00:00Z",
+	},
+	expectError: `timestamp 1000-01-01T12:00:00Z: line-protocol value out of range`,
+}, {
+	testName: "TimeStampTooLate",
+	point: Point{
+		Measurement: "m",
+		Fields: []FieldKeyValue{{
+			Key:   "x",
+			Value: int64(1),
+		}},
+		Time: "8888-01-01T12:00:00Z",
+	},
+	expectError: `timestamp 8888-01-01T12:00:00Z: line-protocol value out of range`,
+}}
+
+func TestEncoderDataError(t *testing.T) {
+	c := qt.New(t)
+	for _, test := range encoderDataErrorTests {
+		c.Run(test.testName, func(c *qt.C) {
+			var e Encoder
+			e.StartLine("m")
+			e.AddField("f", MustNewValue(int64(1)))
+			c.Assert(e.Err(), qt.IsNil)
+			initialBytes := string(e.Bytes())
+			encodePoint(&e, test.point)
+			c.Assert(e.Err(), qt.ErrorMatches, test.expectError)
+
+			// Check that the original line is still intact without any of
+			// the new one.
+			c.Assert(string(e.Bytes()), qt.Equals, initialBytes)
+
+			// Check that we can add another line OK.
+			e.ClearErr()
+			e.StartLine("n")
+			e.AddField("g", MustNewValue(int64(1)))
+			c.Assert(e.Err(), qt.IsNil)
+			c.Assert(string(e.Bytes()), qt.Equals, "m f=1i\nn g=1i")
+		})
+	}
+}
+
+func BenchmarkEncode(b *testing.B) {
+	ts := time.Now()
+	field1Val := []byte("ds;livjdsflvkfesdvljkdsnbvlkdfsjbldfsjhbdfklsjbvkdsjhbv")
+	field2Val := []byte("12343456")
+	benchmarks := []struct {
+		name   string
+		encode func(b *testing.B, encoder *Encoder)
+	}{{
+		name: "100-points",
+		encode: func(b *testing.B, e *Encoder) {
+			for j := 0; j < 100; j++ {
+				e.StartLine("measurement")
+				e.AddTag("tagfffffffdsffsdfvgdsfvdsfvdsfvd1", "blahblahblah")
+				e.AddTag("uag2", "dfsvdfsvbsdfvs")
+				e.AddTag("zzzzzzzzzz", "fdbgfdbgf")
+				v, err := NewValueFromBytes(String, field1Val)
+				if err != nil {
+					b.Fatal(err)
+				}
+				e.AddField("f", v)
+				v, err = NewValueFromBytes(Int, field2Val)
+				if err != nil {
+					b.Fatal(err)
+				}
+				e.AddField("f2", v)
+				e.EndLine(ts)
+			}
+		},
+	}, {
+		name: "1-point",
+		encode: func(b *testing.B, e *Encoder) {
+			e.StartLine("measurement")
+			e.AddTag("tagfffffffdsffsdfvgdsfvdsfvdsfvd1", "blahblahblah")
+			e.AddTag("uag2", "dfsvdfsvbsdfvs")
+			e.AddTag("zzzzzzzzzz", "fdbgfdbgf")
+			v, err := NewValueFromBytes(String, field1Val)
+			if err != nil {
+				b.Fatal(err)
+			}
+			e.AddField("f", v)
+			v, err = NewValueFromBytes(Int, field2Val)
+			if err != nil {
+				b.Fatal(err)
+			}
+			e.AddField("f2", v)
+			e.EndLine(ts)
+		},
+	}}
+	runBench := func(b *testing.B, lax bool) {
+		name := "strict"
+		if lax {
+			name = "lax"
+		}
+		b.Run(name, func(b *testing.B) {
+			for _, benchmark := range benchmarks {
+				b.Run(benchmark.name, func(b *testing.B) {
+					b.ReportAllocs()
+					var e Encoder
+					e.SetLax(lax)
+					benchmark.encode(b, &e)
+					b.SetBytes(int64(len(e.Bytes())))
+					e.Reset()
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						benchmark.encode(b, &e)
+					}
+				})
+			}
+		})
+	}
+	runBench(b, false)
+	runBench(b, true)
+}
+
+func encodePoint(e *Encoder, p Point) {
+	e.StartLine(p.Measurement)
+	for _, tag := range p.Tags {
+		e.AddTag(tag.Key, tag.Value)
+	}
+	for _, field := range p.Fields {
+		e.AddField(field.Key, MustNewValue(field.Value))
+	}
+	var t time.Time
+	if p.Time != "" {
+		if strings.Contains(p.Time, "T") {
+			// Allow RFC3339 time values so we can test out-of-bands
+			// timestamps.
+			t1, err := time.Parse(time.RFC3339, p.Time)
+			if err != nil {
+				panic(err)
+			}
+			t = t1
+		} else {
+			ns, err := strconv.ParseInt(p.Time, 10, 64)
+			if err != nil {
+				panic(err)
+			}
+			t = time.Unix(0, ns)
+		}
+	}
+	e.EndLine(t)
+}
+
+func pointsHaveError(ps []Point) bool {
+	for _, p := range ps {
+		if p.MeasurementError != "" || p.TimeError != "" {
+			return true
+		}
+		for _, tag := range p.Tags {
+			if tag.Error != "" {
+				return true
+			}
+		}
+		for _, field := range p.Fields {
+			if field.Error != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func pointWithSortedTags(p Point) Point {
+	p.Tags = append([]TagKeyValue(nil), p.Tags...)
+	sort.Slice(p.Tags, func(i, j int) bool {
+		return p.Tags[i].Key < p.Tags[j].Key
+	})
+	return p
+}

--- a/influxdata/escape.go
+++ b/influxdata/escape.go
@@ -14,6 +14,9 @@ type escaper struct {
 	// revTable holds the inverse of table - it maps
 	// from escaped value to the unescaped value.
 	revTable [256]byte
+
+	// escapes holds all the characters that need to be escaped.
+	escapes string
 }
 
 // newEscaper returns an escaper that escapes the
@@ -29,5 +32,48 @@ func newEscaper(escapes string) *escaper {
 		e.table[byte(b)] = q[0]         // use single remaining character.
 		e.revTable[q[0]] = byte(b)
 	}
+	e.escapes = escapes
 	return &e
+}
+
+// appendEscaped returns the escaped form of s appended to buf.
+func (e *escaper) appendEscaped(buf []byte, s string) []byte {
+	newLen := e.escapedLen(s)
+	if newLen == len(s) {
+		return append(buf, s...)
+	}
+	if cap(buf)-len(buf) < newLen {
+		nBuf := make([]byte, len(buf), len(buf)+newLen)
+		copy(nBuf, buf)
+		buf = nBuf
+	}
+	e._escape(buf[len(buf):len(buf)+newLen], s)
+	return buf[:len(buf)+newLen]
+}
+
+func (e *escaper) escapedLen(s string) int {
+	n := len(s)
+	for i := 0; i < len(e.escapes); i++ {
+		n += strings.Count(s, e.escapes[i:i+1])
+	}
+	return n
+}
+
+// _escape writes the escaped form of s into buf. It
+// assumes buf is the correct length (as determined
+// by escapedLen).
+// This method should be treated as private to escaper.
+func (e *escaper) _escape(buf []byte, s string) {
+	j := 0
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		if r := e.table[b]; r != 0 {
+			buf[j] = '\\'
+			buf[j+1] = r
+			j += 2
+		} else {
+			buf[j] = b
+			j++
+		}
+	}
 }

--- a/influxdata/tokenizer.go
+++ b/influxdata/tokenizer.go
@@ -259,7 +259,7 @@ func (t *Tokenizer) advanceTagComma() error {
 // fields precede the timestamp in the line-protocol entry.
 //
 // The returned value slice may not be valid: to
-// check its validity, use NewValueFromBytes, or use NextField.
+// check its validity, use NewValueFromBytes(kind, value), or use NextField.
 func (t *Tokenizer) NextFieldBytes() (key []byte, kind ValueKind, value []byte, err error) {
 	if ok, err := t.advanceToSection(FieldSection); err != nil {
 		return nil, Unknown, nil, err
@@ -339,8 +339,7 @@ func (t *Tokenizer) NextFieldBytes() (key []byte, kind ValueKind, value []byte, 
 	return fieldKey, fieldKind, fieldVal, nil
 }
 
-// takeEOL consumes a line terminator. It reports whether
-// a line terminator or the end of input was found.
+// takeEOL consumes input up until the next end of line.
 func (t *Tokenizer) takeEOL() bool {
 	if !t.ensure(1) {
 		// End of input.
@@ -379,7 +378,7 @@ func (t *Tokenizer) NextField() (key []byte, val Value, err error) {
 	if err != nil || key == nil {
 		return nil, Value{}, err
 	}
-	v, err := ParseValue(kind, data)
+	v, err := NewValueFromBytes(kind, data)
 	if err != nil {
 		return nil, Value{}, fmt.Errorf("cannot parse value for field key %q: %w", key, err)
 	}

--- a/influxdata/value_test.go
+++ b/influxdata/value_test.go
@@ -111,7 +111,7 @@ func TestValueCreation(t *testing.T) {
 	c := qt.New(t)
 	for _, test := range parseValueTests {
 		c.Run(test.testName, func(c *qt.C) {
-			v, err := ParseValue(test.kind, []byte(test.data))
+			v, err := NewValueFromBytes(test.kind, []byte(test.data))
 			if test.expectError != "" {
 				c.Assert(err, qt.ErrorMatches, test.expectError)
 			} else {


### PR DESCRIPTION
This implements a low-level `Encoder` type that can be used
as the basis for encoding higher level `Point`-like types.

Usage is quite strict: the caller must call the methods in the expected
order (the same as in the line-protocol syntax).
The advantage this gives is that no buffering is required,
which makes things more efficient by eliminating data copies.

To make the API somewhat less clunky, we use a style that
records the first error encountered rather than returning an error
from each method. This is functionally equivalent (you can
always call `Err` after each call if you like) but much easier for
the common case of just encoding a bunch of data.

One choice this encoder makes differently from other encoders
is to use exponential notation sometimes when encoding float
values. The performance overheads of parsing floats seem fairly
minimal and this can save quite a bit of memory space when encoding
large floating point numbers.

The encoder implements a "lax" mode to make it more efficient to
encode known-good line protocol (for example when obtaining
values that have already been obtained from a line-protocol decoder).
Enabling lax mode gives a ~35% performance increase.

Here are the benchmark numbers recorded on my machine for the
new Encoder implementation:

```
goos: linux
goarch: amd64
pkg: github.com/influxdata/line-protocol/v2/influxdata
cpu: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
BenchmarkEncode/strict/100-points-8                17160             69777 ns/op         276.58 MB/s      117774 B/op          0 allocs/op
BenchmarkEncode/strict/100-points-8                17884             70154 ns/op         275.09 MB/s      113006 B/op          0 allocs/op
BenchmarkEncode/strict/100-points-8                17464             68794 ns/op         280.53 MB/s      115724 B/op          0 allocs/op
BenchmarkEncode/strict/100-points-8                17374             72748 ns/op         265.28 MB/s      116324 B/op          0 allocs/op
BenchmarkEncode/strict/100-points-8                16858             73443 ns/op         262.77 MB/s      119884 B/op          0 allocs/op
BenchmarkEncode/strict/1-point-8                 1648060               719.7 ns/op       266.77 MB/s         981 B/op          0 allocs/op
BenchmarkEncode/strict/1-point-8                 1634002               733.4 ns/op       261.78 MB/s         989 B/op          0 allocs/op
BenchmarkEncode/strict/1-point-8                 1582335               750.4 ns/op       255.86 MB/s        1021 B/op          0 allocs/op
BenchmarkEncode/strict/1-point-8                 1567088               748.9 ns/op       256.37 MB/s        1031 B/op          0 allocs/op
BenchmarkEncode/strict/1-point-8                 1790156               714.6 ns/op       268.69 MB/s        1129 B/op          0 allocs/op
BenchmarkEncode/lax/100-points-8                   22990             62890 ns/op         306.87 MB/s      109891 B/op          0 allocs/op
BenchmarkEncode/lax/100-points-8                   23506             58269 ns/op         331.21 MB/s      107479 B/op          0 allocs/op
BenchmarkEncode/lax/100-points-8                   23161             57824 ns/op         333.76 MB/s      109080 B/op          0 allocs/op
BenchmarkEncode/lax/100-points-8                   22785             58050 ns/op         332.45 MB/s      110880 B/op          0 allocs/op
BenchmarkEncode/lax/100-points-8                   21904             60361 ns/op         319.73 MB/s      115340 B/op          0 allocs/op
BenchmarkEncode/lax/1-point-8                    2063863               597.5 ns/op       321.32 MB/s         979 B/op          0 allocs/op
BenchmarkEncode/lax/1-point-8                    2015706               604.3 ns/op       317.71 MB/s        1002 B/op          0 allocs/op
BenchmarkEncode/lax/1-point-8                    1972352               595.7 ns/op       322.30 MB/s        1024 B/op          0 allocs/op
BenchmarkEncode/lax/1-point-8                    2061008               589.3 ns/op       325.79 MB/s         980 B/op          0 allocs/op
BenchmarkEncode/lax/1-point-8                    1991053               680.2 ns/op       282.26 MB/s        1015 B/op          0 allocs/op
```
