### PR TITLE
influxdata: rename Tokenizer to Decoder

### DIFF
--- a/influxdata/encoder.go
+++ b/influxdata/encoder.go
@@ -213,7 +213,7 @@ func (e *Encoder) AddField(key string, value Value) {
 // TODO would it be better for this to be:
 //	AddFieldRaw(key []byte, kind ValueKind, data []byte) error
 // so that we could respect lax and be more efficient when reading directly
-// from a Tokenizer?
+// from a Decoder?
 func (e *Encoder) AddFieldRaw(key []byte, value Value) {
 	e.AddField(unsafeBytesToString(key), value)
 }

--- a/influxdata/encoder_test.go
+++ b/influxdata/encoder_test.go
@@ -10,10 +10,10 @@ import (
 	qt "github.com/frankban/quicktest"
 )
 
-func TestEncoderWithTokenizerTests(t *testing.T) {
+func TestEncoderWithDecoderTests(t *testing.T) {
 	c := qt.New(t)
 	runTests := func(c *qt.C, lax bool) {
-		for _, test := range tokenizerTests {
+		for _, test := range decoderTests {
 			if pointsHaveError(test.expect) {
 				// Can't encode a test that results in an error.
 				continue
@@ -34,8 +34,8 @@ func TestEncoderWithTokenizerTests(t *testing.T) {
 				data := e.Bytes()
 				c.Logf("encoded: %q", data)
 				// Check that the data round-trips OK
-				tok := NewTokenizerWithBytes(data)
-				assertTokenizeResult(c, tok, points, false)
+				dec := NewDecoderWithBytes(data)
+				assertDecodeResult(c, dec, points, false)
 			})
 		}
 	}

--- a/influxdata/value.go
+++ b/influxdata/value.go
@@ -46,7 +46,7 @@ func (v1 Value) Equal(v2 Value) bool {
 }
 
 // NewValueFromBytes creates a value of the given kind with the
-// given data, as returned from Tokenizer.NextFieldBytes.
+// given data, as returned from Decoder.NextFieldBytes.
 //
 // If the value is out of range, errors.Is(err, ErrValueOutOfRange) will return true.
 //


### PR DESCRIPTION
Now we've got an `Encoder` type, the name `Tokenizer` seems
a bit ambiguous (does it produce tokens or consume them?) and
`Decoder` seems like a nicer name for the opposite of encoding.