### PR TITLE
influxdata: include line and column in decoder errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.15
 
 require (
 	github.com/frankban/quicktest v1.11.0
-	github.com/google/go-cmp v0.5.2
+	github.com/google/go-cmp v0.5.5
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/frankban/quicktest v1.11.0 h1:Yyrghcw93e1jKo4DTZkRFTTFvBsVhzbblBUPNU1
 github.com/frankban/quicktest v1.11.0/go.mod h1:K+q6oSqb0W0Ininfk863uOk1lMy69l/P6txr3mVT54s=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/influxdata/encoder_test.go
+++ b/influxdata/encoder_test.go
@@ -35,7 +35,7 @@ func TestEncoderWithDecoderTests(t *testing.T) {
 				c.Logf("encoded: %q", data)
 				// Check that the data round-trips OK
 				dec := NewDecoderWithBytes(data)
-				assertDecodeResult(c, dec, points, false)
+				assertDecodeResult(c, dec, points, false, errPositions{})
 			})
 		}
 	}


### PR DESCRIPTION
All Decoder methods now return `*DecoderError` on error,
which allow for more accurate pinpointing of problematic
entries.

Benchmark comparison:

```
name                                                           old time/op    new time/op    delta
DecodeEntriesSkipping/long-lines-8                               17.0ms ± 2%    17.9ms ± 0%   +5.08%  (p=0.008 n=5+5)
DecodeEntriesSkipping/long-lines-with-escapes-8                  17.7ms ± 2%    18.8ms ± 3%   +6.10%  (p=0.008 n=5+5)
DecodeEntriesSkipping/single-short-line-8                         348ns ±20%     306ns ± 6%     ~     (p=0.690 n=5+5)
DecodeEntriesSkipping/single-short-line-with-escapes-8            397ns ± 8%     387ns ± 2%     ~     (p=0.690 n=5+5)
DecodeEntriesSkipping/many-short-lines-8                          175ms ± 2%     178ms ± 2%     ~     (p=0.151 n=5+5)
DecodeEntriesSkipping/field-key-escape-not-escapable-8            357ns ±16%     354ns ± 8%     ~     (p=0.841 n=5+5)
DecodeEntriesSkipping/tag-value-triple-escape-space-8             487ns ±14%     497ns ± 1%     ~     (p=0.190 n=5+4)
DecodeEntriesSkipping/procstat-8                                 3.59µs ± 7%    3.82µs ± 2%     ~     (p=0.056 n=5+5)
DecodeEntriesWithoutSkipping/long-lines-8                        26.6ms ± 6%    29.4ms ± 7%  +10.74%  (p=0.032 n=5+5)
DecodeEntriesWithoutSkipping/long-lines-with-escapes-8            114ms ± 1%     115ms ± 0%   +1.61%  (p=0.008 n=5+5)
DecodeEntriesWithoutSkipping/single-short-line-8                  497ns ± 0%     534ns ±10%     ~     (p=0.111 n=4+5)
DecodeEntriesWithoutSkipping/single-short-line-with-escapes-8     526ns ± 2%     631ns ±15%  +19.90%  (p=0.016 n=5+5)
DecodeEntriesWithoutSkipping/many-short-lines-8                   253ms ±11%     255ms ±10%     ~     (p=0.841 n=5+5)
DecodeEntriesWithoutSkipping/field-key-escape-not-escapable-8     461ns ± 2%     470ns ± 2%     ~     (p=0.310 n=5+5)
DecodeEntriesWithoutSkipping/tag-value-triple-escape-space-8      545ns ± 1%     562ns ± 3%   +3.22%  (p=0.032 n=5+5)
DecodeEntriesWithoutSkipping/procstat-8                          6.19µs ± 6%    6.79µs ± 5%   +9.70%  (p=0.008 n=5+5)

name                                                           old speed      new speed      delta
DecodeEntriesSkipping/long-lines-8                             1.54GB/s ± 2%  1.46GB/s ± 0%   -4.84%  (p=0.008 n=5+5)
DecodeEntriesSkipping/long-lines-with-escapes-8                1.48GB/s ± 2%  1.40GB/s ± 3%   -5.72%  (p=0.008 n=5+5)
DecodeEntriesSkipping/single-short-line-8                      85.4MB/s ±19%  94.9MB/s ± 5%     ~     (p=0.690 n=5+5)
DecodeEntriesSkipping/single-short-line-with-escapes-8         80.9MB/s ± 8%  82.8MB/s ± 2%     ~     (p=0.690 n=5+5)
DecodeEntriesSkipping/many-short-lines-8                        150MB/s ± 2%   148MB/s ± 2%     ~     (p=0.151 n=5+5)
DecodeEntriesSkipping/field-key-escape-not-escapable-8         92.9MB/s ±14%  93.5MB/s ± 8%     ~     (p=0.841 n=5+5)
DecodeEntriesSkipping/tag-value-triple-escape-space-8           103MB/s ±13%   101MB/s ± 1%     ~     (p=0.190 n=5+4)
DecodeEntriesSkipping/procstat-8                                370MB/s ± 6%   348MB/s ± 2%     ~     (p=0.056 n=5+5)
DecodeEntriesWithoutSkipping/long-lines-8                       987MB/s ± 6%   893MB/s ± 7%   -9.58%  (p=0.032 n=5+5)
DecodeEntriesWithoutSkipping/long-lines-with-escapes-8          231MB/s ± 1%   227MB/s ± 0%   -1.59%  (p=0.008 n=5+5)
DecodeEntriesWithoutSkipping/single-short-line-8               57.9MB/s ± 3%  54.5MB/s ±10%     ~     (p=0.222 n=5+5)
DecodeEntriesWithoutSkipping/single-short-line-with-escapes-8  60.8MB/s ± 2%  51.2MB/s ±17%  -15.85%  (p=0.016 n=5+5)
DecodeEntriesWithoutSkipping/many-short-lines-8                 104MB/s ±11%   103MB/s ± 9%     ~     (p=0.841 n=5+5)
DecodeEntriesWithoutSkipping/field-key-escape-not-escapable-8  71.5MB/s ± 2%  70.2MB/s ± 2%     ~     (p=0.310 n=5+5)
DecodeEntriesWithoutSkipping/tag-value-triple-escape-space-8   91.8MB/s ± 1%  89.0MB/s ± 3%   -3.09%  (p=0.032 n=5+5)
DecodeEntriesWithoutSkipping/procstat-8                         215MB/s ± 5%   196MB/s ± 5%   -8.86%  (p=0.008 n=5+5)

name                                                           old alloc/op   new alloc/op   delta
DecodeEntriesSkipping/long-lines-8                                 512B ± 0%      512B ± 0%     ~     (all equal)
DecodeEntriesSkipping/long-lines-with-escapes-8                    512B ± 0%      512B ± 0%     ~     (all equal)
DecodeEntriesSkipping/single-short-line-8                          512B ± 0%      512B ± 0%     ~     (all equal)
DecodeEntriesSkipping/single-short-line-with-escapes-8             512B ± 0%      512B ± 0%     ~     (all equal)
DecodeEntriesSkipping/many-short-lines-8                           512B ± 0%      512B ± 0%     ~     (p=0.889 n=5+4)
DecodeEntriesSkipping/field-key-escape-not-escapable-8             512B ± 0%      512B ± 0%     ~     (all equal)
DecodeEntriesSkipping/tag-value-triple-escape-space-8              512B ± 0%      512B ± 0%     ~     (all equal)
DecodeEntriesSkipping/procstat-8                                   512B ± 0%      512B ± 0%     ~     (all equal)
DecodeEntriesWithoutSkipping/long-lines-8                          512B ± 0%      512B ± 0%     ~     (all equal)
DecodeEntriesWithoutSkipping/long-lines-with-escapes-8           19.5kB ± 0%    19.5kB ± 0%     ~     (all equal)
DecodeEntriesWithoutSkipping/single-short-line-8                   512B ± 0%      512B ± 0%     ~     (all equal)
DecodeEntriesWithoutSkipping/single-short-line-with-escapes-8      512B ± 0%      512B ± 0%     ~     (all equal)
DecodeEntriesWithoutSkipping/many-short-lines-8                    512B ± 0%      512B ± 0%     ~     (all equal)
DecodeEntriesWithoutSkipping/field-key-escape-not-escapable-8      512B ± 0%      512B ± 0%     ~     (all equal)
DecodeEntriesWithoutSkipping/tag-value-triple-escape-space-8       512B ± 0%      512B ± 0%     ~     (all equal)
DecodeEntriesWithoutSkipping/procstat-8                            512B ± 0%      512B ± 0%     ~     (all equal)

name                                                           old allocs/op  new allocs/op  delta
DecodeEntriesSkipping/long-lines-8                                 1.00 ± 0%      1.00 ± 0%     ~     (all equal)
DecodeEntriesSkipping/long-lines-with-escapes-8                    1.00 ± 0%      1.00 ± 0%     ~     (all equal)
DecodeEntriesSkipping/single-short-line-8                          1.00 ± 0%      1.00 ± 0%     ~     (all equal)
DecodeEntriesSkipping/single-short-line-with-escapes-8             1.00 ± 0%      1.00 ± 0%     ~     (all equal)
DecodeEntriesSkipping/many-short-lines-8                           1.00 ± 0%      1.00 ± 0%     ~     (all equal)
DecodeEntriesSkipping/field-key-escape-not-escapable-8             1.00 ± 0%      1.00 ± 0%     ~     (all equal)
DecodeEntriesSkipping/tag-value-triple-escape-space-8              1.00 ± 0%      1.00 ± 0%     ~     (all equal)
DecodeEntriesSkipping/procstat-8                                   1.00 ± 0%      1.00 ± 0%     ~     (all equal)
DecodeEntriesWithoutSkipping/long-lines-8                          1.00 ± 0%      1.00 ± 0%     ~     (all equal)
DecodeEntriesWithoutSkipping/long-lines-with-escapes-8             8.00 ± 0%      8.00 ± 0%     ~     (all equal)
DecodeEntriesWithoutSkipping/single-short-line-8                   1.00 ± 0%      1.00 ± 0%     ~     (all equal)
DecodeEntriesWithoutSkipping/single-short-line-with-escapes-8      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
DecodeEntriesWithoutSkipping/many-short-lines-8                    1.00 ± 0%      1.00 ± 0%     ~     (all equal)
DecodeEntriesWithoutSkipping/field-key-escape-not-escapable-8      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
DecodeEntriesWithoutSkipping/tag-value-triple-escape-space-8       1.00 ± 0%      1.00 ± 0%     ~     (all equal)
DecodeEntriesWithoutSkipping/procstat-8                            1.00 ± 0%      1.00 ± 0%     ~     (all equal)
```
