### PR TITLE
feat: add typed constructors for Value

### DIFF
--- a/influxdata/value.go
+++ b/influxdata/value.go
@@ -128,7 +128,7 @@ func NewValue(x interface{}) (Value, bool) {
 	case int64:
 		return IntValue(x), true
 	case uint64:
-		return UIntValue(x), true
+		return UintValue(x), true
 	case float64:
 		return FloatValue(x)
 	case bool:
@@ -149,8 +149,8 @@ func IntValue(x int64) Value {
 	}
 }
 
-// UIntValue returns a Value containing the value of x.
-func UIntValue(x uint64) Value {
+// UintValue returns a Value containing the value of x.
+func UintValue(x uint64) Value {
 	return Value{
 		number: uint64(x),
 		bytes:  uintSentinel[:],

--- a/influxdata/value.go
+++ b/influxdata/value.go
@@ -159,7 +159,7 @@ func UintValue(x uint64) Value {
 
 // FloatValue returns a Value containing the value of x.
 //
-// FloatValue will fail and return false if x is a +/- infinity or NaN.
+// FloatValue will fail and return false if x is non-finite.
 func FloatValue(x float64) (Value, bool) {
 	if math.IsInf(x, 0) || math.IsNaN(x) {
 		return Value{}, false


### PR DESCRIPTION
This helps the user avoid the possibility of passing, for example, an
`int` instead of `int64` to `NewValue`.

Also added UTF-8 checks to `NewValue` via these new constructors.