### PR TITLE
influxdata: use bytes for column offset

### DIFF
--- a/influxdata/decoder.go
+++ b/influxdata/decoder.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"time"
-	"unicode/utf8"
 )
 
 const (
@@ -821,7 +820,7 @@ func (d *Decoder) syntaxErrorf(offset int, f string, a ...interface{}) error {
 	} else {
 		columnBytes = buf
 	}
-	column := 1 + utf8.RuneCount(columnBytes)
+	column := len(columnBytes) + 1
 
 	// Note: line corresponds to the current line at d.r1, so if
 	// there are any newlines after the location of the error, we need to
@@ -843,7 +842,7 @@ func (d *Decoder) syntaxErrorf(offset int, f string, a ...interface{}) error {
 type DecodeError struct {
 	// Line holds the one-based index of the line where the error occurred.
 	Line int64
-	// Column holds the one-based index of the column where the error occurred.
+	// Column holds the one-based index of the column (in bytes) where the error occurred.
 	Column int
 	// Err holds the underlying error.
 	Err error

--- a/influxdata/decoder_test.go
+++ b/influxdata/decoder_test.go
@@ -1247,7 +1247,7 @@ func makeErrPositions(text string) (errPositions, string) {
 			buf = append(buf, text[:size]...)
 		default:
 			buf = append(buf, text[:size]...)
-			currPos.column++
+			currPos.column += size
 		}
 		text = text[size:]
 	}
@@ -1276,12 +1276,12 @@ func TestErrorPositions(t *testing.T) {
 	}, {
 		text:       "a\nbác∑¹helélo∑²blah\n∑³x\n",
 		err:        "foo: at line ∑¹: blah",
-		expectErr:  "foo: at line 2:4: blah",
+		expectErr:  "foo: at line 2:5: blah",
 		expectText: "a\nbácheléloblah\nx\n",
 	}, {
 		text:       "a\nbác∑¹helélo∑²blah\n∑³x\n",
 		err:        "foo: at line ∑²: blah",
-		expectErr:  "foo: at line 2:10: blah",
+		expectErr:  "foo: at line 2:12: blah",
 		expectText: "a\nbácheléloblah\nx\n",
 	}, {
 		text:       "a\nbác∑¹helélo∑²blah\n∑³x\n",


### PR DESCRIPTION
[This comment](https://github.com/golang/go/issues/44221#issuecomment-811993362) related
to columns in the encoding/csv package made me realise that we should do
byte offset, not rune offset.