### PR TITLE
chore: update gopkg.in/yaml.v3 to 3.0.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.15.2
+      - image: circleci/golang:1.17.5
 
     working_directory: /go/src/github.com/influxdata/line-protocol
     steps:

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/frankban/quicktest v1.13.0
 	github.com/google/go-cmp v0.5.5
 	github.com/influxdata/line-protocol-corpus v0.0.0-20210922080147-aa28ccfb8937
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,6 @@ github.com/frankban/quicktest v1.13.0/go.mod h1:qLE0fzW0VuyUAJgPU19zByoIr0HtCHN/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/influxdata/line-protocol-corpus v0.0.0-20210514154603-cfca080a1b17 h1:9cv6vqPG8kbd32vhGtaxJGR5FZgew77DciLF6+9Jf30=
-github.com/influxdata/line-protocol-corpus v0.0.0-20210514154603-cfca080a1b17/go.mod h1:03nmhxzZ7Xk2pdG+lmMd7mHDfeVOYFyhOgwO61qWU98=
 github.com/influxdata/line-protocol-corpus v0.0.0-20210519164801-ca6fa5da0184 h1:modYba1g1we+YJf0yGTwmohVWVAxcAch18nPg3e24OY=
 github.com/influxdata/line-protocol-corpus v0.0.0-20210519164801-ca6fa5da0184/go.mod h1:03nmhxzZ7Xk2pdG+lmMd7mHDfeVOYFyhOgwO61qWU98=
 github.com/influxdata/line-protocol-corpus v0.0.0-20210922080147-aa28ccfb8937 h1:MHJNQ+p99hFATQm6ORoLmpUCF7ovjwEFshs/NHzAbig=
@@ -30,3 +28,5 @@ gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8X
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/lineprotocol/strconv.go
+++ b/lineprotocol/strconv.go
@@ -41,9 +41,10 @@ func parseBoolBytes(s []byte) (byte, error) {
 // It is unsafe, and is intended to prepare input to short-lived functions
 // that require strings.
 func unsafeBytesToString(data []byte) string {
-	dataHeader := *(*reflect.SliceHeader)(unsafe.Pointer(&data))
-	return *(*string)(unsafe.Pointer(&reflect.StringHeader{
-		Data: dataHeader.Data,
-		Len:  dataHeader.Len,
-	}))
+	dataHeader := (*reflect.SliceHeader)(unsafe.Pointer(&data))
+	var str string
+	stringHeader := (*reflect.StringHeader)(unsafe.Pointer(&str))
+	stringHeader.Data = dataHeader.Data
+	stringHeader.Len = dataHeader.Len
+	return str
 }


### PR DESCRIPTION
This is to resolve a dependabot alert.
```
$ go mod edit -require=gopkg.in/yaml.v3@v3.0.1
$ go mod tidy
$ go test ./...
```

CircleCI tests would fail because `honnef.co/go/tools` needed go 1.17. I update `./.circleci/config.yml` to use 1.17.5 (the latest 1.17 image they have), but now `go vet` fails with:
```
# github.com/influxdata/line-protocol/v2/lineprotocol
lineprotocol/strconv.go:44:16: possible misuse of reflect.SliceHeader
lineprotocol/strconv.go:45:35: possible misuse of reflect.StringHeader

Exited with code exit status 2
```