### PR TITLE
feat(verify-lp): provide a cgo hook for verifying lp from python

### DIFF
--- a/cmd/verify-lines/README.md
+++ b/cmd/verify-lines/README.md
@@ -1,0 +1,40 @@
+## Verify your Line Protocol
+
+verify-lines.go is provided to allow calling the LP decoder from Python to check line protocol for errors.
+
+To do so, first build a shared object line for your system from the root of this project.
+
+```bash
+go build -buildmode=c-shared -o verify-lines.so ./cmd/verify-lines/verify-lines.go
+```
+
+Then within your Python script or program, run these:
+
+```python
+import ctypes
+so = ctypes.cdll.LoadLibrary('./verify-lines.so')
+verifyLines = so.verifyLines
+```
+
+Then you can check single line protocol lines or batches of them. Encoding to utf8 is required.
+
+```python
+>>> verifyLines('foo,tag1=val1,tag2=val2 x=1,y="hello" 1625823259000000'.encode('utf-8'))
+0
+>>> verifyLines('foo,,,, 1625823259000000'.encode('utf-8'))
+at line 1:5: expected tag key or field but found ',' instead
+1
+>>> batch="""##comment
+... "foo",tag1=val1,"tag2"="tag
+... " x2=1,y="hel
+... lo" 1625823259000000
+... _bar enabled=true
+... foo,bar=a\\ x=1 x=1"""
+>>> verifyLines(batch.encode('utf-8'))
+at line 2:28: expected tag key or field but found '\n' instead
+at line 6:13: empty tag key
+1
+```
+
+The error messages explain where the first error in each line occurred. There may be more than one error in a line.
+The line count is 1 indexed.

--- a/cmd/verify-lines/verify-lines.go
+++ b/cmd/verify-lines/verify-lines.go
@@ -1,0 +1,65 @@
+package main
+
+import "C"
+import (
+	"fmt"
+	"os"
+
+	"github.com/influxdata/line-protocol/v2/lineprotocol"
+)
+
+func main() {}
+
+// verifyLines provides a cgo hook to verify line protocol strings.
+// The method will print encountered decode errors to stderr and returns
+// a boolean to indicate if any errors where encountered following the
+// unix standard of 0 for success and 1 for error conditions.
+// It will continue to decode and verify all lines even after encountering
+// an error. The line immediately after an error may verify but not be
+// what was intended.
+//export verifyLines
+func verifyLines(lines *C.char) C.int {
+	dec := lineprotocol.NewDecoderWithBytes([]byte(C.GoString(lines)))
+	var failure bool
+	logErr := func(err error) {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		failure = true
+	}
+nextLine:
+	for dec.Next() {
+		_, err := dec.Measurement()
+		if err != nil {
+			logErr(err)
+			continue nextLine
+		}
+		for {
+			key, _, err := dec.NextTag()
+			if err != nil {
+				logErr(err)
+				continue nextLine
+			}
+			if key == nil {
+				break
+			}
+		}
+		for {
+			key, _, err := dec.NextField()
+			if err != nil {
+				logErr(err)
+				continue nextLine
+			}
+			if key == nil {
+				break
+			}
+		}
+		if _, err := dec.TimeBytes(); err != nil {
+			logErr(err)
+			continue nextLine
+		}
+	}
+	if failure {
+		return 1
+	} else {
+		return 0
+	}
+}


### PR DESCRIPTION
This CS creates a function verifyLines that can be called via cgo from
python. Instructions are provided in the readme.